### PR TITLE
Adding checks for the ffprobe and ffplay as both are used too.

### DIFF
--- a/week2/day5.ipynb
+++ b/week2/day5.ipynb
@@ -356,7 +356,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ffmpeg -version"
+    "!ffmpeg -version\n",
+    "!ffprobe -version\n",
+    "!ffplay -version"
    ]
   },
   {


### PR DESCRIPTION
Hi Ed,
On my Mac I was not using homebrew as the way to install my binaries for some personal reasons.
Regarding FFmpeg library I used a static builds (https://osxexperts.net), when I called your notebook it showed me errors as creating audio requires ffprobe and ffplay libraries as well.

After installing and activating all of them it worked fine.
May be it is worth adding these two version checks too.