### PR TITLE
chore: add missing dependencies for non-Anaconda users

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,5 @@ bitsandbytes
 psutil
 setuptools
 speedtest-cli
+sentence_transformers
+feedparser


### PR DESCRIPTION
Couple of deps were only present in `environment.yml`, this tiny change adds them to `requirements.txt` in order to use standard Python virtual env's.