### PR TITLE
add ollama with streams using ollama generate

### DIFF
--- a/week1/community-contributions/week1_Ollama_generate_streams.ipynb
+++ b/week1/community-contributions/week1_Ollama_generate_streams.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe12c203-e6a6-452c-a655-afb8a03a4ff5",
+   "metadata": {},
+   "source": [
+    "# End of week 1 exercise\n",
+    "\n",
+    "To demonstrate your familiarity with OpenAI API, and also Ollama, build a tool that takes a technical question,  \n",
+    "and responds with an explanation. This is a tool that you will be able to use yourself during the course!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1070317-3ed9-4659-abe3-828943230e03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "import os\n",
+    "import requests\n",
+    "import json\n",
+    "from typing import List\n",
+    "from dotenv import load_dotenv\n",
+    "from bs4 import BeautifulSoup\n",
+    "from IPython.display import Markdown, display, update_display\n",
+    "from openai import OpenAI\n",
+    "import ollama"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a456906-915a-4bfd-bb9d-57e505c5093f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# constants\n",
+    "MODEL_GPT = 'gpt-4o-mini'\n",
+    "MODEL_LLAMA = 'llama3.2'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8d7923c-5f28-4c30-8556-342d7c8497c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set up environment\n",
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv('OPENAI_API_KEY')\n",
+    "\n",
+    "if api_key and api_key.startswith('sk-proj-') and len(api_key)>10:\n",
+    "    print(\"API key looks good so far\")\n",
+    "else:\n",
+    "    print(\"There might be a problem with your API key? Please visit the troubleshooting notebook!\")\n",
+    "\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f0d0137-52b0-47a8-81a8-11a90a010798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"You are provided with a technical question. \\\n",
+    "You are answering by providing a quick explanation and giving some examples.\\n\"\n",
+    "\n",
+    "# here is the question; type over this to ask something new\n",
+    "question = \"\"\"\n",
+    "Please explain what this code does and why:\n",
+    "yield from {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60ce7000-a4a5-4cce-a261-e75ef45063b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get gpt-4o-mini to answer, with streaming\n",
+    "def get_answer_gpt():\n",
+    "    stream = openai.chat.completions.create(\n",
+    "        model=MODEL_GPT,\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": system_prompt},\n",
+    "            {\"role\": \"user\", \"content\": question}\n",
+    "          ],\n",
+    "        stream=True\n",
+    "    )\n",
+    "\n",
+    "    response = \"\"\n",
+    "    display_handle = display(Markdown(\"\"), display_id=True)\n",
+    "    for chunk in stream:\n",
+    "        response += chunk.choices[0].delta.content or ''\n",
+    "        response = response.replace(\"```\",\"\").replace(\"markdown\", \"\")\n",
+    "        update_display(Markdown(response), display_id=display_handle.display_id)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f7c8ea8-4082-4ad0-8751-3301adcf6538",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Llama 3.2 to answer\n",
+    "def get_answer_ollama():\n",
+    "    stream = ollama.generate(\n",
+    "        MODEL_LLAMA,\n",
+    "        question,\n",
+    "        stream=True\n",
+    "    )\n",
+    "     \n",
+    "    response = \"\"\n",
+    "    display_handle = display(Markdown(\"\"), display_id=True)\n",
+    "    for chunk in stream:\n",
+    "        response += chunk['response'] or ''\n",
+    "        response = response.replace(\"```\",\"\").replace(\"markdown\", \"\")\n",
+    "        update_display(Markdown(response), display_id=display_handle.display_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a859eb1-23fa-40dd-ba91-b35084433a00",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_answer_gpt()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c73f046-da3a-49a5-8a74-4b8a86a9032a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_answer_ollama()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bea20f33-a710-44ab-9a4d-856db05e4201",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
As part of Week 1 exercise, for the ollama calling function I used `ollama.generate()` instead of `ollama.chat()`. It also uses streams, although it was not required for this challenge.

This was based on the examples on the ollama-python repository: https://github.com/ollama/ollama-python/tree/main/examples.