### PR TITLE
Update to environment.yml for Pytorch

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - numpy
   - pandas
   - scipy
-  - pytorch
   - jupyterlab
   - ipywidgets
   - matplotlib
@@ -48,3 +47,6 @@ dependencies:
     - feedparser
     - twilio
     - pydub
+    - torch
+    - torchvision
+    - torchaudio


### PR DESCRIPTION
Pytorch no longer has support for conda packages. Moved pytorch to pip.