### PR TITLE
Fix execute_cpp function when creating compiler_cmd for different OS

### DIFF
--- a/week4/day4.ipynb
+++ b/week4/day4.ipynb
@@ -777,10 +777,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "038cbb80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def execute_cpp(code, compiler_cmd):\n",
+    "    write_output(code)\n",
+    "\n",
+    "    try:\n",
+    "        compile_result = subprocess.run(compiler_cmd, check=True, text=True, capture_output=True)\n",
+    "        run_cmd = [\"./optimized\"]\n",
+    "        run_result = subprocess.run(run_cmd, check=True, text=True, capture_output=True)\n",
+    "        return run_result.stdout\n",
+    "    except subprocess.CalledProcessError as e:\n",
+    "        return f\"An error occurred:\\n{e.stderr}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "f9ca2e6f-60c1-4e5f-b570-63c75b2d189b",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from functools import partial\n",
+    "\n",
     "compiler_cmd = c_compiler_cmd(\"optimized\")\n",
     "\n",
     "with gr.Blocks(css=css) as ui:\n",
@@ -810,7 +831,7 @@
     "    sample_program.change(select_sample_program, inputs=[sample_program], outputs=[python])\n",
     "    convert.click(optimize, inputs=[python, model], outputs=[cpp])\n",
     "    python_run.click(execute_python, inputs=[python], outputs=[python_out])\n",
-    "    cpp_run.click(execute_cpp, inputs=[cpp], outputs=[cpp_out])\n",
+    "    cpp_run.click(partial(execute_cpp, compiler_cmd=compiler_cmd[2]), inputs=[cpp], outputs=[cpp_out])\n",
     "\n",
     "ui.launch(inbrowser=True)"
    ]


### PR DESCRIPTION
When using c_compiler_cmd function for creating compile_cmd for different Os (i.e Linux, Window, ...), should pass this created compile_cmd to the execute_cpp function, instead of using the default one.