### PR TITLE
Delay initial yield to avoid raw Markdown rendering in Gradio

### DIFF
--- a/week2/day2.ipynb
+++ b/week2/day2.ipynb
@@ -318,8 +318,12 @@
     "    )\n",
     "    result = \"\"\n",
     "    for chunk in stream:\n",
-    "        result += chunk.choices[0].delta.content or \"\"\n",
-    "        yield result"
+    "        next_token = chunk.choices[0].delta.content or \"\"\n",
+    "        result += next_token\n",
+    "        # Gradio's Markdown renderer may show raw text if the first few yields contain incomplete Markdown syntax\n",
+    "        # (e.g. an opening \"**\" without closing). To avoid this, we delay yielding until a meaningful chunk is built up.\n",
+    "        if len(result.strip()) > 50:\n",
+    "            yield result"
    ]
   },
   {


### PR DESCRIPTION
Gradio's Markdown output can render as raw text if the first few streamed tokens form incomplete syntax (e.g. unclosed bold or headers). This change adds a buffer before yielding to ensure the first chunk is syntactically valid Markdown.