### PR TITLE
fix: LangChainDeprecationWarning on langchain_embeddings import

### DIFF
--- a/week5/day3.ipynb
+++ b/week5/day3.ipynb
@@ -3,7 +3,13 @@
   {
    "cell_type": "markdown",
    "id": "dfe37963-1af6-44fc-a841-8e462443f5e6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Expert Knowledge Worker\n",
     "\n",
@@ -174,8 +180,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "75f7d622-9a85-4690-83c8-6310393a0189",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Needed to fix the LangChainDeprecationWarning\n",
+    "!pip install -U langchain-huggingface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "78998399-ac17-4e28-b15f-0b5f51e6ee23",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Put the chunks of data into a Vector Store that associates a Vector Embedding with each chunk\n",
@@ -184,8 +213,9 @@
     "\n",
     "# If you would rather use the free Vector Embeddings from HuggingFace sentence-transformers\n",
     "# Then replace embeddings = OpenAIEmbeddings()\n",
+    "# Use langchain_huggingface instead of langchain.embeddings to avoid deprecation warning\n",
     "# with:\n",
-    "# from langchain.embeddings import HuggingFaceEmbeddings\n",
+    "# from langchain_huggingface import HuggingFaceEmbeddings\n",
     "# embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")"
    ]
   },
@@ -358,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,

--- a/week5/day4.ipynb
+++ b/week5/day4.ipynb
@@ -3,7 +3,13 @@
   {
    "cell_type": "markdown",
    "id": "dfe37963-1af6-44fc-a841-8e462443f5e6",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## Expert Knowledge Worker\n",
     "\n",
@@ -138,6 +144,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25d950ac-94cf-48c2-86e1-9551019db914",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Needed to fix the LangChainDeprecationWarning\n",
+    "!pip install -U langchain-huggingface"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "77f7d2a6-ccfa-425b-a1c3-5e55b23bd013",
    "metadata": {},
@@ -162,7 +185,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "78998399-ac17-4e28-b15f-0b5f51e6ee23",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Put the chunks of data into a Vector Store that associates a Vector Embedding with each chunk\n",
@@ -172,8 +201,9 @@
     "\n",
     "# If you would rather use the free Vector Embeddings from HuggingFace sentence-transformers\n",
     "# Then replace embeddings = OpenAIEmbeddings()\n",
+    "# Use langchain_huggingface instead of langchain.embeddings to avoid deprecation warning\n",
     "# with:\n",
-    "# from langchain.embeddings import HuggingFaceEmbeddings\n",
+    "# from langchain_huggingface import HuggingFaceEmbeddings\n",
     "# embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")\n",
     "\n",
     "# Delete if already exists\n",

--- a/week5/day5.ipynb
+++ b/week5/day5.ipynb
@@ -139,8 +139,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3a98c92a-0864-4670-8075-301558ae71d6",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Needed to fix the LangChainDeprecationWarning\n",
+    "!pip install -U langchain-huggingface"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "78998399-ac17-4e28-b15f-0b5f51e6ee23",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Put the chunks of data into a Vector Store that associates a Vector Embedding with each chunk\n",
@@ -150,8 +173,9 @@
     "\n",
     "# If you would rather use the free Vector Embeddings from HuggingFace sentence-transformers\n",
     "# Then replace embeddings = OpenAIEmbeddings()\n",
+    "# Use langchain_huggingface instead of langchain.embeddings to avoid deprecation warning\n",
     "# with:\n",
-    "# from langchain.embeddings import HuggingFaceEmbeddings\n",
+    "# from langchain_huggingface import HuggingFaceEmbeddings\n",
     "# embeddings = HuggingFaceEmbeddings(model_name=\"sentence-transformers/all-MiniLM-L6-v2\")\n",
     "\n",
     "# Delete if already exists\n",
@@ -475,7 +499,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The class `HuggingFaceEmbeddings` was deprecated in LangChain 0.2.2 and will be removed in 1.0.

Theses changes fixes the warning.

Added a new cell:
`!pip install -U langchain-huggingface`

And edited the comments in the cell after to use the right import

Replaced: from `langchain_embeddings import HuggingFaceEmbeddings`
WIth: `from langchain_huggingface import HuggingFaceEmbeddings`