### PR TITLE
New Wandb integration to fix issues on Week's 6 Day 5 Notebook.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ nohup.out
 *.png
 
 scraper_cache/
+
+# WandB local sync data.
+wandb/

--- a/environment.yml
+++ b/environment.yml
@@ -44,3 +44,4 @@ dependencies:
     - twilio
     - pydub
     - protobuf==3.20.2
+    - wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ speedtest-cli
 sentence_transformers
 feedparser
 protobuf==3.20.2
+wandb

--- a/week6/day5.ipynb
+++ b/week6/day5.ipynb
@@ -149,7 +149,7 @@
    "source": [
     "# First let's work on a good prompt for a Frontier model\n",
     "# Notice that I'm removing the \" to the nearest dollar\"\n",
-    "# When we train our own models, we'll need to make the problem as easy as possible, \n",
+    "# When we train our own models, we'll need to make the problem as easy as possible,\n",
     "# but a Frontier model needs no such simplification.\n",
     "\n",
     "def messages_for(item):\n",
@@ -394,6 +394,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b19ea9e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import wandb\n",
+    "from wandb.integration.openai.fine_tuning import WandbLogger\n",
+    "\n",
+    "# Log in to Weights & Biases.\n",
+    "wandb.login()\n",
+    "# Sync the fine-tuning job with Weights & Biases.\n",
+    "WandbLogger.sync(fine_tune_job_id=job_id, project=\"gpt-pricer\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "066fef03-8338-4526-9df3-89b649ad4f0a",
    "metadata": {},
@@ -490,7 +506,7 @@
     "\n",
     "def gpt_fine_tuned(item):\n",
     "    response = openai.chat.completions.create(\n",
-    "        model=fine_tuned_model_name, \n",
+    "        model=fine_tuned_model_name,\n",
     "        messages=messages_for(item),\n",
     "        seed=42,\n",
     "        max_tokens=7\n",


### PR DESCRIPTION
Seems recently Wandb integration with OpenAI has changed and now it's required to run a "sync" command locally to make it update project's results from OpenAI to Wandb dashboards.

> [!WARNING]  
> Ensure to add the `WANDB_API_KEY` to your `.env` file with the Wandb api key, the same we placed on the OpenAI before.

> [!CAUTION]  
> Requirements and environment files for Pip and Anaconda has been updated but, as I make use of Pipenv, I've not properly tested that change, please review that specially.

I placed all changes on the same cell just before **Step 3** to make it more easy to expose the changes, consider moving imports and `login()` lines to the top of the notebook, where those steps are usually taken if required.

* Project name could be parametrized too:  `project_name="gpt-pricer"`
  
  
P.d: I'm the "Panda" on Udemy 😉 

P.p.d: My IDE, VSCode, auto trims trailing spaces on save, so lines 152 and 493 changes are just that. 😅 