### PR TITLE
Add Gemini streaming support to brochure generator

### DIFF
--- a/week2/day2.ipynb
+++ b/week2/day2.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "c44c5494-950d-4d2f-8d4f-b87b57c5b330",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "d1715421-cead-400b-99af-986388a97aff",
    "metadata": {},
    "outputs": [],
@@ -45,20 +45,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "337d5dfc-0181-4e3b-8ab9-e78e0c3f657b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "OpenAI API Key exists and begins sk-proj-\n",
-      "Anthropic API Key exists and begins sk-ant-\n",
-      "Google API Key exists and begins AIzaSyA5\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load environment variables in a file called .env\n",
     "# Print the key prefixes to help with any debugging\n",
@@ -86,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "22586021-1795-4929-8079-63f5bb4edd4c",
    "metadata": {},
    "outputs": [],
@@ -102,7 +92,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "b16e6021-6dc4-4397-985a-6679d6c8ffd5",
    "metadata": {},
    "outputs": [],
@@ -114,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "02ef9b69-ef31-427d-86d0-b8c799e1c1b1",
    "metadata": {},
    "outputs": [],
@@ -135,21 +125,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "aef7d314-2b13-436b-b02d-8de3b72b193f",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\"Today's date is October 10, 2023.\""
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# This can reveal the \"training cut off\", or the most recent date in the training data\n",
     "\n",
@@ -166,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "bc664b7a-c01d-4fea-a1de-ae22cdd5141a",
    "metadata": {},
    "outputs": [],
@@ -180,67 +159,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "083ea451-d3a0-4d13-b599-93ed49b975e4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Shout has been called with input hello\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'HELLO'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "shout(\"hello\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "08f1f15a-122e-4502-b112-6ee2817dda32",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7860\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7860/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# The simplicty of gradio. This might appear in \"light mode\" - I'll show you how to make this in dark mode later.\n",
     "\n",
@@ -249,41 +181,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "c9a359a4-685c-4c99-891c-bb4d1cb7f426",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7861\n",
-      "* Running on public URL: https://c1f6ab5bdc2722c539.gradio.live\n",
-      "\n",
-      "This share link expires in 1 week. For free permanent hosting and GPU upgrades, run `gradio deploy` from the terminal in the working directory to deploy to Hugging Face Spaces (https://huggingface.co/spaces)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"https://c1f6ab5bdc2722c539.gradio.live\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Adding share=True means that it can be accessed publically\n",
     "# A more permanent hosting is available using a platform called Spaces from HuggingFace, which we will touch on next week\n",
@@ -294,39 +195,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "cd87533a-ff3a-4188-8998-5bedd5ba2da3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7862\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7862/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Adding inbrowser=True opens up a new browser window automatically\n",
     "\n",
@@ -345,39 +217,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "e8129afa-532b-4b15-b93c-aa9cca23a546",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7863\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7863/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Define this variable and then pass js=force_dark_mode when creating the Interface\n",
     "\n",
@@ -395,39 +238,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "3cc67b26-dd5f-406d-88f6-2306ee2950c0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7865\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7865/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Inputs and Outputs\n",
     "\n",
@@ -442,39 +256,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "f235288e-63a2-4341-935b-1441f9be969b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7866\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7866/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# And now - changing the function from \"shout\" to \"message_gpt\"\n",
     "\n",
@@ -489,39 +274,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "af9a3262-e626-4e4b-80b0-aca152405e63",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7867\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7867/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Let's use Markdown\n",
     "# Are you wondering why it makes any difference to set system_message when it's not referred to in the code below it?\n",
@@ -541,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "88c04ebf-0671-4fea-95c9-bc1565d4bb4f",
    "metadata": {},
    "outputs": [],
@@ -568,39 +324,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "0bb1f789-ff11-4cba-ac67-11b815e29d09",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7868\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7868/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view = gr.Interface(\n",
     "    fn=stream_gpt,\n",
@@ -613,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "bbc8e930-ba2a-4194-8f7c-044659150626",
    "metadata": {},
    "outputs": [],
@@ -637,39 +364,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "a0066ffd-196e-4eaf-ad1e-d492958b62af",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7869\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7869/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view = gr.Interface(\n",
     "    fn=stream_claude,\n",
@@ -705,7 +403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "0087623a-4e31-470b-b2e6-d8d16fc7bcf5",
    "metadata": {},
    "outputs": [],
@@ -722,39 +420,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "8d8ce810-997c-4b6a-bc4f-1fc847ac8855",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7870\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7870/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view = gr.Interface(\n",
     "    fn=stream_model,\n",
@@ -797,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "1626eb2e-eee8-4183-bda5-1591b58ae3cf",
    "metadata": {},
    "outputs": [],
@@ -825,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "c701ec17-ecd5-4000-9f68-34634c8ed49d",
    "metadata": {},
    "outputs": [],
@@ -838,7 +507,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
+   "id": "baa7a732",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stream_gemini(prompt):\n",
+    "    response = genai.chat.completions.create(\n",
+    "        model=\"gemini-2.5-flash\",\n",
+    "        messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+    "        stream=True  # Enable streaming\n",
+    "    )\n",
+    "    \n",
+    "    for chunk in response:\n",
+    "        if chunk.choices[0].delta.content is not None:\n",
+    "            yield chunk.choices[0].delta.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "5def90e0-4343-4f58-9d4a-0e36e445efa4",
    "metadata": {},
    "outputs": [],
@@ -851,6 +539,8 @@
     "        result = stream_gpt(prompt)\n",
     "    elif model==\"Claude\":\n",
     "        result = stream_claude(prompt)\n",
+    "    elif model == \"Gemini\":\n",
+    "        result = stream_gemini(prompt)\n",
     "    else:\n",
     "        raise ValueError(\"Unknown model\")\n",
     "    yield from result"
@@ -858,46 +548,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "66399365-5d67-4984-9d47-93ed26c0bd3d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "* Running on local URL:  http://127.0.0.1:7873\n",
-      "* To create a public link, set `share=True` in `launch()`.\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div><iframe src=\"http://127.0.0.1:7873/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": []
-     },
-     "execution_count": 30,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "view = gr.Interface(\n",
     "    fn=stream_brochure,\n",
     "    inputs=[\n",
     "        gr.Textbox(label=\"Company name:\"),\n",
     "        gr.Textbox(label=\"Landing page URL including http:// or https://\"),\n",
-    "        gr.Dropdown([\"GPT\", \"Claude\"], label=\"Select model\")],\n",
+    "        gr.Dropdown([\"GPT\", \"Claude\", \"Gemini\"], label=\"Select model\")],\n",
     "    outputs=[gr.Markdown(label=\"Brochure:\")],\n",
     "    flagging_mode=\"never\"\n",
     ")\n",
@@ -915,7 +576,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "llms",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
# Add Gemini Streaming Support to Brochure Generator

This PR adds support for using Google's Gemini model in the brochure generator, alongside the existing GPT and Claude options.

## Changes
- Added `stream_gemini` function to handle Gemini API streaming responses
- Updated `stream_brochure` to support Gemini model option
- Added Gemini to model dropdown in UI
- Maintains consistent streaming pattern with GPT and Claude implementations

## Implementation Details
- Uses Gemini's streaming API with the same pattern as GPT and Claude
- Handles streaming chunks consistently with other models
- Preserves markdown formatting in responses
- Maintains same error handling pattern as other models

## Testing
The implementation has been tested with:
- Basic company website URLs
- Streaming functionality works as expected
- UI updates in real-time as responses are generated

## Requirements
- Requires Google API key to be configured (same as existing setup)
- Uses `gemini-2.5-flash` model for optimal performance
- No additional dependencies required beyond existing ones

## Notes
- Follows the same streaming pattern as existing models for consistency
- Uses the OpenAI-compatible endpoint for better integration
- Maintains the same error handling patterns