### PR TITLE
Fix environment.yml pytorch install with Cuda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: llms
 channels:
+  - pytorch
   - conda-forge
   - defaults
 dependencies:
@@ -12,6 +13,8 @@ dependencies:
   - hf-xet==1.1.9
   - scipy
   - pytorch
+  - torchvision
+  - torchaudio
   - jupyterlab
   - ipywidgets
   - matplotlib


### PR DESCRIPTION
The Pytorch installation using conda was giving the following error:
Downloading and Extracting Packages: InvalidArchiveError('Error with archive C:\\Users\\my_local_user\\anaconda3\\pkgs\\pytorch-2.8.0-cuda128_mkl_py311_hd9a8a8a_300')
I found that adding pytorch to the channels, and adding torchvision and torchaudio fixed the problem.
Hopefully this sounds like a good solution