### PR TITLE
Product price estimator using open source model

### DIFF
--- a/week7/community_contributions/emmy/product_price_estimator.ipynb
+++ b/week7/community_contributions/emmy/product_price_estimator.ipynb
@@ -1,0 +1,454 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "275415f0",
+      "metadata": {
+        "id": "275415f0"
+      },
+      "outputs": [],
+      "source": [
+        "# pip installs\n",
+        "\n",
+        "!pip install -q --upgrade torch==2.5.1+cu124 torchvision==0.20.1+cu124 torchaudio==2.5.1+cu124 --index-url https://download.pytorch.org/whl/cu124\n",
+        "!pip install -q --upgrade requests==2.32.3 bitsandbytes==0.46.0 transformers==4.48.3 accelerate==1.3.0 datasets==3.2.0 peft==0.14.0 trl==0.14.0 matplotlib wandb"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "535bd9de",
+      "metadata": {
+        "id": "535bd9de"
+      },
+      "outputs": [],
+      "source": [
+        "# imports\n",
+        "\n",
+        "import os\n",
+        "import re\n",
+        "import math\n",
+        "from tqdm import tqdm\n",
+        "import numpy as np\n",
+        "from google.colab import userdata\n",
+        "from huggingface_hub import login\n",
+        "import torch\n",
+        "from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score, mean_absolute_percentage_error\n",
+        "import torch.nn.functional as F\n",
+        "import transformers\n",
+        "from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig, set_seed\n",
+        "from datasets import load_dataset, Dataset, DatasetDict\n",
+        "from datetime import datetime\n",
+        "from peft import PeftModel\n",
+        "import matplotlib.pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "fc58234a",
+      "metadata": {
+        "id": "fc58234a"
+      },
+      "outputs": [],
+      "source": [
+        "# Constants\n",
+        "\n",
+        "BASE_MODEL = \"meta-llama/Meta-Llama-3.1-8B\"\n",
+        "PROJECT_NAME = \"pricer\"\n",
+        "HF_USER = \"ed-donner\"\n",
+        "RUN_NAME = \"2024-09-13_13.04.39\"\n",
+        "PROJECT_RUN_NAME = f\"{PROJECT_NAME}-{RUN_NAME}\"\n",
+        "REVISION = \"e8d637df551603dc86cd7a1598a8f44af4d7ae36\"\n",
+        "FINETUNED_MODEL = f\"{HF_USER}/{PROJECT_RUN_NAME}\"\n",
+        "\n",
+        "\n",
+        "DATASET_NAME = f\"{HF_USER}/home-data\"\n",
+        "\n",
+        "QUANT_4_BIT = True\n",
+        "top_K = 6\n",
+        "\n",
+        "%matplotlib inline\n",
+        "\n",
+        "# Used for writing to output in color\n",
+        "\n",
+        "GREEN = \"\\033[92m\"\n",
+        "YELLOW = \"\\033[93m\"\n",
+        "RED = \"\\033[91m\"\n",
+        "RESET = \"\\033[0m\"\n",
+        "COLOR_MAP = {\"red\":RED, \"orange\": YELLOW, \"green\": GREEN}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "0145ad8a",
+      "metadata": {
+        "id": "0145ad8a"
+      },
+      "outputs": [],
+      "source": [
+        "# Log in to HuggingFace\n",
+        "\n",
+        "hf_token = userdata.get('HF_TOKEN')\n",
+        "login(hf_token, add_to_git_credential=True)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6919506e",
+      "metadata": {
+        "id": "6919506e"
+      },
+      "outputs": [],
+      "source": [
+        "dataset = load_dataset(DATASET_NAME)\n",
+        "train = dataset['train']\n",
+        "test = dataset['test']\n",
+        "len(train), len(test)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ea79cde1",
+      "metadata": {
+        "id": "ea79cde1"
+      },
+      "outputs": [],
+      "source": [
+        "if QUANT_4_BIT:\n",
+        "  quant_config = BitsAndBytesConfig(\n",
+        "    load_in_4bit=True,\n",
+        "    bnb_4bit_use_double_quant=True,\n",
+        "    bnb_4bit_compute_dtype=torch.bfloat16,\n",
+        "    bnb_4bit_quant_type=\"nf4\"\n",
+        "  )\n",
+        "else:\n",
+        "  quant_config = BitsAndBytesConfig(\n",
+        "    load_in_8bit=True,\n",
+        "  )"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "ef108f8d",
+      "metadata": {
+        "id": "ef108f8d"
+      },
+      "outputs": [],
+      "source": [
+        "# Load the Tokenizer and the Model\n",
+        "\n",
+        "tokenizer = AutoTokenizer.from_pretrained(BASE_MODEL, trust_remote_code=True)\n",
+        "tokenizer.pad_token = tokenizer.eos_token\n",
+        "tokenizer.padding_side = \"right\"\n",
+        "\n",
+        "base_model = AutoModelForCausalLM.from_pretrained(\n",
+        "    BASE_MODEL,\n",
+        "    quantization_config=quant_config,\n",
+        "    device_map=\"auto\",\n",
+        ")\n",
+        "base_model.generation_config.pad_token_id = tokenizer.pad_token_id\n",
+        "\n",
+        "# Load the fine-tuned model with PEFT\n",
+        "if REVISION:\n",
+        "    fine_tuned_model = PeftModel.from_pretrained(base_model, FINETUNED_MODEL, revision=REVISION)\n",
+        "else:\n",
+        "    fine_tuned_model = PeftModel.from_pretrained(base_model, FINETUNED_MODEL)\n",
+        "\n",
+        "fine_tuned_model.eval()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "7f3c4176",
+      "metadata": {
+        "id": "7f3c4176"
+      },
+      "outputs": [],
+      "source": [
+        "def extract_price(s):\n",
+        "    if \"Price is $\" in s:\n",
+        "      contents = s.split(\"Price is $\")[1]\n",
+        "      contents = contents.replace(',','')\n",
+        "      match = re.search(r\"[-+]?\\d*\\.\\d+|\\d+\", contents)\n",
+        "      return float(match.group()) if match else 0\n",
+        "    return 0"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "436fa29a",
+      "metadata": {
+        "id": "436fa29a"
+      },
+      "outputs": [],
+      "source": [
+        "# Original prediction function takes the most likely next token\n",
+        "\n",
+        "def model_predict(prompt):\n",
+        "    set_seed(42)\n",
+        "    inputs = tokenizer.encode(prompt, return_tensors=\"pt\").to(\"cuda\")\n",
+        "    attention_mask = torch.ones(inputs.shape, device=\"cuda\")\n",
+        "    outputs = fine_tuned_model.generate(inputs, attention_mask=attention_mask, max_new_tokens=3, num_return_sequences=1)\n",
+        "    response = tokenizer.decode(outputs[0])\n",
+        "    return extract_price(response)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a666dab6",
+      "metadata": {
+        "id": "a666dab6"
+      },
+      "outputs": [],
+      "source": [
+        "def improved_model_predict(prompt, device=\"cuda\", top_k=3):\n",
+        "    set_seed(42)\n",
+        "    inputs = tokenizer.encode(prompt, return_tensors=\"pt\").to(device)\n",
+        "    attention_mask = torch.ones_like(inputs)\n",
+        "\n",
+        "    with torch.no_grad():\n",
+        "        outputs = fine_tuned_model(inputs, attention_mask=attention_mask)\n",
+        "        next_token_logits = outputs.logits[:, -1, :].to(\"cpu\")\n",
+        "\n",
+        "    probs = F.softmax(next_token_logits, dim=-1)\n",
+        "    top_prob, top_token_id = probs.topk(top_k)\n",
+        "\n",
+        "    prices, weights = [], []\n",
+        "    for weight, token_id in zip(top_prob[0], top_token_id[0]):\n",
+        "        token_text = tokenizer.decode(token_id)\n",
+        "        try:\n",
+        "            value = float(token_text)\n",
+        "        except ValueError:\n",
+        "            continue\n",
+        "        prices.append(value)\n",
+        "        weights.append(weight.item())\n",
+        "\n",
+        "    if not prices:\n",
+        "        return 0.0, 0.0, 0.0  # price, confidence, spread\n",
+        "\n",
+        "    total = sum(weights)\n",
+        "    normalized = [w / total for w in weights]\n",
+        "    weighted_price = sum(p * w for p, w in zip(prices, normalized))\n",
+        "    variance = sum(w * (p - weighted_price) ** 2 for p, w in zip(prices, normalized))\n",
+        "    confidence = 1 - min(variance / (weighted_price + 1e-6), 1)\n",
+        "    spread = max(prices) - min(prices)\n",
+        "    return weighted_price, confidence, spread"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install -q gradio>=4.0\n",
+        "import gradio as gr\n",
+        "\n",
+        "def format_prediction(description):\n",
+        "  price, confidence, spread = improved_model_predict(description)\n",
+        "  return (\n",
+        "      f\"${price:,.2f}\",\n",
+        "      f\"{confidence*100:.1f}%\",\n",
+        "      f\"${spread:,.2f}\",\n",
+        "  )\n",
+        "\n",
+        "demo = gr.Interface(\n",
+        "    fn=format_prediction,\n",
+        "    inputs=gr.Textbox(lines=10, label=\"Product Description\"),\n",
+        "    outputs=[\n",
+        "        gr.Textbox(label=\"Estimated Price\"),\n",
+        "        gr.Textbox(label=\"Confidence\"),\n",
+        "        gr.Textbox(label=\"Token Spread\"),\n",
+        "    ],\n",
+        "    title=\"Open-Source Product Price Estimator\",\n",
+        "    description=\"Paste a cleaned product blurb. The model returns a price estimate, a confidence score based on top-k token dispersion, and the spread between top predictions.\",\n",
+        ")\n",
+        "\n",
+        "demo.launch(share=True)"
+      ],
+      "metadata": {
+        "id": "Km4tHaeQyMoW"
+      },
+      "id": "Km4tHaeQyMoW",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "9664c4c7",
+      "metadata": {
+        "id": "9664c4c7"
+      },
+      "outputs": [],
+      "source": [
+        "\n",
+        "class Tester:\n",
+        "\n",
+        "    def __init__(self, predictor, data, title=None, show_progress=True):\n",
+        "        self.predictor = predictor\n",
+        "        self.data = data\n",
+        "        self.title = title or predictor.__name__.replace(\"_\", \" \").title()\n",
+        "        self.size = len(data)\n",
+        "        self.guesses, self.truths, self.errors, self.rel_errors, self.sles, self.colors = [], [], [], [], [], []\n",
+        "        self.show_progress = show_progress\n",
+        "\n",
+        "    def color_for(self, error, truth):\n",
+        "        if error < 40 or error / truth < 0.2:\n",
+        "            return \"green\"\n",
+        "        elif error < 80 or error / truth < 0.4:\n",
+        "            return \"orange\"\n",
+        "        else:\n",
+        "            return \"red\"\n",
+        "\n",
+        "    def run_datapoint(self, i):\n",
+        "        datapoint = self.data[i]\n",
+        "        guess = self.predictor(datapoint[\"text\"])\n",
+        "        truth = datapoint[\"price\"]\n",
+        "\n",
+        "        error = guess - truth\n",
+        "        abs_error = abs(error)\n",
+        "        rel_error = abs_error / truth if truth != 0 else 0\n",
+        "        log_error = math.log(truth + 1) - math.log(guess + 1)\n",
+        "        sle = log_error ** 2\n",
+        "        color = self.color_for(abs_error, truth)\n",
+        "\n",
+        "        title = (datapoint[\"text\"].split(\"\\n\\n\")[1][:20] + \"...\") if \"\\n\\n\" in datapoint[\"text\"] else datapoint[\"text\"][:20]\n",
+        "        self.guesses.append(guess)\n",
+        "        self.truths.append(truth)\n",
+        "        self.errors.append(error)\n",
+        "        self.rel_errors.append(rel_error)\n",
+        "        self.sles.append(sle)\n",
+        "        self.colors.append(color)\n",
+        "\n",
+        "        print(f\"{COLOR_MAP[color]}{i+1}: Guess: ${guess:,.2f} Truth: ${truth:,.2f} \"\n",
+        "              f\"Error: ${abs_error:,.2f} RelErr: {rel_error*100:.1f}% SLE: {sle:,.2f} Item: {title}{RESET}\")\n",
+        "\n",
+        "    def chart_all(self, chart_title):\n",
+        "        \"\"\"Compact version: 4 performance charts in one grid.\"\"\"\n",
+        "        t, g = np.array(self.truths), np.array(self.guesses)\n",
+        "        rel_err, abs_err = np.array(self.rel_errors) * 100, np.abs(np.array(self.errors))\n",
+        "\n",
+        "        fig, axs = plt.subplots(2, 2, figsize=(14, 10))\n",
+        "        fig.suptitle(f\"Performance Dashboard — {chart_title}\", fontsize=16, fontweight=\"bold\")\n",
+        "\n",
+        "        # Scatter plot\n",
+        "        max_val = max(t.max(), g.max()) * 1.05\n",
+        "        axs[1, 1].plot([0, max_val], [0, max_val], \"b--\", alpha=0.6)\n",
+        "        axs[1, 1].scatter(t, g, s=20, c=self.colors, alpha=0.6)\n",
+        "        axs[1, 1].set_title(\"Predictions vs Ground Truth\")\n",
+        "        axs[1, 1].set_xlabel(\"True Price ($)\")\n",
+        "        axs[1, 1].set_ylabel(\"Predicted ($)\")\n",
+        "\n",
+        "        # Accuracy by price range\n",
+        "        bins = np.linspace(t.min(), t.max(), 6)\n",
+        "        labels = [f\"${bins[i]:.0f}–${bins[i+1]:.0f}\" for i in range(len(bins)-1)]\n",
+        "        inds = np.digitize(t, bins) - 1\n",
+        "        avg_err = [rel_err[inds == i].mean() for i in range(len(labels))]\n",
+        "        axs[0, 0].bar(labels, avg_err, color=\"seagreen\", alpha=0.8)\n",
+        "        axs[0, 0].set_title(\"Avg Relative Error by Price Range\")\n",
+        "        axs[0, 0].set_ylabel(\"Relative Error (%)\")\n",
+        "        axs[0, 0].tick_params(axis=\"x\", rotation=30)\n",
+        "\n",
+        "        # Relative error distribution\n",
+        "        axs[0, 1].hist(rel_err, bins=25, color=\"mediumpurple\", edgecolor=\"black\", alpha=0.7)\n",
+        "        axs[0, 1].set_title(\"Relative Error Distribution (%)\")\n",
+        "        axs[0, 1].set_xlabel(\"Relative Error (%)\")\n",
+        "\n",
+        "        # Absolute error distribution\n",
+        "        axs[1, 0].hist(abs_err, bins=25, color=\"steelblue\", edgecolor=\"black\", alpha=0.7)\n",
+        "        axs[1, 0].axvline(abs_err.mean(), color=\"red\", linestyle=\"--\", label=f\"Mean={abs_err.mean():.2f}\")\n",
+        "        axs[1, 0].set_title(\"Absolute Error Distribution\")\n",
+        "        axs[1, 0].set_xlabel(\"Absolute Error ($)\")\n",
+        "        axs[1, 0].legend()\n",
+        "\n",
+        "        for ax in axs.ravel():\n",
+        "            ax.grid(alpha=0.3)\n",
+        "\n",
+        "        plt.tight_layout(rect=[0, 0, 1, 0.95])\n",
+        "        plt.show()\n",
+        "\n",
+        "    def report(self):\n",
+        "        y_true = np.array(self.truths)\n",
+        "        y_pred = np.array(self.guesses)\n",
+        "\n",
+        "        mae = mean_absolute_error(y_true, y_pred)\n",
+        "        rmse = math.sqrt(mean_squared_error(y_true, y_pred))\n",
+        "        rmsle = math.sqrt(sum(self.sles) / self.size)\n",
+        "        mape = mean_absolute_percentage_error(y_true, y_pred) * 100\n",
+        "        median_error = float(np.median(np.abs(y_true - y_pred)))\n",
+        "        r2 = r2_score(y_true, y_pred)\n",
+        "\n",
+        "        hit_rate_green = sum(1 for c in self.colors if c == \"green\") / self.size * 100\n",
+        "        hit_rate_acceptable = sum(1 for c in self.colors if c in (\"green\", \"orange\")) / self.size * 100\n",
+        "\n",
+        "        print(f\"\\n{'='*70}\")\n",
+        "        print(f\"FINAL REPORT: {self.title}\")\n",
+        "        print(f\"{'='*70}\")\n",
+        "        print(f\"Total Predictions: {self.size}\")\n",
+        "        print(f\"\\n--- Error Metrics ---\")\n",
+        "        print(f\"Mean Absolute Error (MAE): ${mae:,.2f}\")\n",
+        "        print(f\"Median Error: ${median_error:,.2f}\")\n",
+        "        print(f\"Root Mean Squared Error (RMSE): ${rmse:,.2f}\")\n",
+        "        print(f\"Root Mean Squared Log Error (RMSLE): {rmsle:.4f}\")\n",
+        "        print(f\"Mean Absolute Percentage Error (MAPE): {mape:.2f}%\")\n",
+        "        print(f\"\\n--- Accuracy Metrics ---\")\n",
+        "        print(f\"R² Score: {r2:.4f}\")\n",
+        "        print(f\"Hit Rate (Green): {hit_rate_green:.1f}%\")\n",
+        "        print(f\"Hit Rate (Green+Orange): {hit_rate_acceptable:.1f}%\")\n",
+        "        print(f\"{'='*70}\\n\")\n",
+        "        chart_title = f\"{self.title} | MAE=${mae:,.2f} | RMSLE={rmsle:.3f} | R²={r2:.3f}\"\n",
+        "\n",
+        "        self.chart_all(chart_title)\n",
+        "\n",
+        "    def run(self):\n",
+        "        iterator = tqdm(range(self.size), desc=\"Testing Model\") if self.show_progress else range(self.size)\n",
+        "        for i in iterator:\n",
+        "            self.run_datapoint(i)\n",
+        "        self.report()\n",
+        "\n",
+        "    @classmethod\n",
+        "    def test(cls, function, data, title=None):\n",
+        "        cls(function, data, title=title).run()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "2e60a696",
+      "metadata": {
+        "id": "2e60a696"
+      },
+      "outputs": [],
+      "source": [
+        "Tester.test(\n",
+        "    improved_model_predict,\n",
+        "    test,\n",
+        "    title=\"Home appliances prediction\"\n",
+        ")"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    },
+    "colab": {
+      "provenance": [],
+      "gpuType": "T4"
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "accelerator": "GPU"
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
# Product Price Estimator

Recreates the Week 6 price-prediction challenge using Ed Donner's fine-tuned LoRA adapter built on top of `meta-llama/Meta-Llama-3.1-8B`. 

## Overview

The shared tester harness reports **MAE**, **RMSLE**, and **hit rate** so you can compare against GPT-4o and the untuned Llama base model.

## Interactive Demo

To make the project feel like a product, a **Gradio demo** turns the model into an interactive widget. Paste a product blurb and it returns:

- Estimated price
- Confidence score (derived from the top-k token distribution)
- Spread value (hints at prediction uncertainty)

## Key Insights

The write-up reflects on pitfalls and lessons learned:

- Avoiding price leakage in prompts
- Handling token parsing quirks
- Understanding model prediction patterns

## Future Improvements

- Lightweight fine-tuning on alternative adapters
- Adding category-aware prompts
- Hosting the Gradio UI for longer-term demos
- Experimenting with different base models

<img width="449" height="242" alt="Screenshot 2025-11-03 at 4 33 29 AM" src="https://github.com/user-attachments/assets/3f131031-87aa-462b-b3c8-d28e67a09f2c" />
<img width="1779" height="985" alt="wee7" src="https://github.com/user-attachments/assets/53ae9be4-954a-4e0d-b1fd-a2653e6cc147" />
<img width="1338" height="514" alt="Screenshot 2025-11-03 at 4 49 16 AM" src="https://github.com/user-attachments/assets/81198db1-def5-4b58-ba0d-ea8f3f7f752c" />