### PR TITLE
Add love poem generator notebook utilizing OpenAI and Ollama APIs

### DIFF
--- a/week1/community-contributions/week1_day1_love_poem_generator.ipynb
+++ b/week1/community-contributions/week1_day1_love_poem_generator.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe12c203-e6a6-452c-a655-afb8a03a4ff5",
+   "metadata": {},
+   "source": [
+    "# End of week 1 exercise\n",
+    "\n",
+    "To demonstrate my familiarity with OpenAI API, and also Ollama, here is a tool that generates a love poem based on the users prompts in specific languages."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ea775a9-12c7-4a63-a676-d7bd0cdb100c",
+   "metadata": {},
+   "source": [
+    "# imports\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display, update_display\n",
+    "from openai import OpenAI\n",
+    "import ollama"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "98961a52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "import os\n",
+    "import requests\n",
+    "import json\n",
+    "from typing import List\n",
+    "from dotenv import load_dotenv\n",
+    "from bs4 import BeautifulSoup\n",
+    "from IPython.display import Markdown,display,update_display\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4a456906-915a-4bfd-bb9d-57e505c5093f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# constants\n",
+    "MODEL_GPT = 'gpt-4o-mini'\n",
+    "MODEL_LLAMA = 'llama3.2'\n",
+    "\n",
+    "LANGUAGES = ['English', 'Spanish', 'French', 'German', 'Italian', 'Nigerian Pidgin', 'Yoruba', 'Hausa', 'Igbo']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a8d7923c-5f28-4c30-8556-342d7c8497c1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API key found and looks good so far!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set up environment\n",
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv('OPENAI_API_KEY')\n",
+    "\n",
+    "if not api_key:\n",
+    "    print(\"No API key was found!\")\n",
+    "else:\n",
+    "    print(\"API key found and looks good so far!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "296b8851",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# function to input a valid language\n",
+    "def inputLanguage():\n",
+    "    print(\"Select a language from the following options:\")\n",
+    "    for idx, lang in enumerate(LANGUAGES, start=1):\n",
+    "        print(f\"{idx}. {lang}\")\n",
+    "    choice = int(input(\"Enter the number corresponding to your choice: \"))\n",
+    "    if 1 <= choice <= len(LANGUAGES):\n",
+    "        return LANGUAGES[choice - 1]\n",
+    "    else:\n",
+    "        print(\"Invalid choice. Defaulting to English.\")\n",
+    "        return \"English\"\n",
+    "    \n",
+    "# function to input a valid lover's name\n",
+    "def inputLoversName():\n",
+    "    name = input(\"Enter your lover's name: \").strip()\n",
+    "    if name:\n",
+    "        return name\n",
+    "    else:\n",
+    "        print(\"Name cannot be empty. Please try again.\")\n",
+    "        return inputLoversName()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f0d0137-52b0-47a8-81a8-11a90a010798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ask for user inputs\n",
+    "language = inputLanguage()\n",
+    "lover_name = inputLoversName()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "967aac6b-9f9c-4def-8659-d9382b0c59e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"You are a world class poet who can create beautiful and evocative poetry of maximum 10 lines from any word given. Each line of the poem should end rhyming with the given lover's name.\"\n",
+    "user_prompt = \"Please create a poem with each line end rhyming with the lover's name: \" + lover_name + \". The poem should be in \" + language + \" language.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7936b5af-e912-4e0e-b43e-87673c4857cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": system_prompt},\n",
+    "    {\"role\": \"user\", \"content\": user_prompt}\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60ce7000-a4a5-4cce-a261-e75ef45063b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get gpt-4o-mini to answer, with streaming\n",
+    "openai = OpenAI()\n",
+    "stream = openai.chat.completions.create(model=MODEL_GPT, messages=messages, stream=True)\n",
+    "response = \"\"\n",
+    "display_handle = display(Markdown(\"\"), display_id=True)\n",
+    "for chunk in stream:\n",
+    "    response += chunk.choices[0].delta.content or ''\n",
+    "    response = response.replace(\"```\",\"\").replace(\"markdown\", \"\")\n",
+    "    update_display(Markdown(response), display_id=display_handle.display_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f7c8ea8-4082-4ad0-8751-3301adcf6538",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Llama 3.2 to answer\n",
+    "response = ollama.chat(model=MODEL_LLAMA, messages=messages)\n",
+    "result = response['message']['content']\n",
+    "display(Markdown(result))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29e9cdd3-5adc-4428-9758-f761dc91783a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a new Jupyter notebook, `week1/community-contributions/week1_day1_love_poem_generator.ipynb`, which demonstrates the use of both OpenAI and Ollama APIs to generate personalized love poems in various languages. The notebook guides users through selecting a language and entering a lover's name, then generates a poem using either the GPT or Llama models.

**Notebook functionality and user experience:**

* Implements user prompts for selecting a language from a predefined list and entering a lover's name, with input validation and default fallbacks.
* Constructs system and user prompts to generate a poem where each line rhymes with the lover's name, supporting multiple languages.

**Model integration and output display:**

* Integrates both OpenAI's GPT-4o-mini and Ollama's Llama 3.2 models to generate poems, with streaming output for GPT and formatted display for both models.
* Uses `IPython.display` to show the generated poem in markdown format for improved readability in the notebook interface.

**Code structure and dependencies:**

* Includes all necessary imports, environment setup using `dotenv`, and kernel metadata for reproducibility and compatibility.