### PR TITLE
Clarify first code-cell run instructions in week1/day1

### DIFF
--- a/week1/day1.ipynb
+++ b/week1/day1.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "### If you're new to working in \"Notebooks\" (also known as Labs or Jupyter Lab)\n",
     "\n",
-    "Welcome to the wonderful world of Data Science experimentation! Simply click in each \"cell\" with code in it, such as the cell immediately below this text, and hit Shift+Return to execute that cell. Be sure to run every cell, starting at the top, in order.\n",
+    "Welcome to the wonderful world of Data Science experimentation! In a notebook, you run code by clicking in a “code” cell and pressing Shift+Return to execute it. A bit further below, after you’ve selected a kernel, you’ll run your first code cell. When you do, be sure to run every cell, starting at the top, in order.\n",
     "\n",
     "Please look in the [Guides folder](../guides/01_intro.ipynb) for all the guides.\n",
     "\n",
@@ -99,7 +99,9 @@
     "\n",
     "Any problems with this? Head over to the troubleshooting.\n",
     "\n",
-    "### Note: you'll need to set the Kernel with every notebook.."
+    "### Note: you'll need to set the Kernel with every notebook..\n",
+    "\n",
+    "And now it’s time to run your first code cell. Simply click inside the \"cell\" with code, immediately below this text, and hit Shift+Return to execute that cell."
    ]
   },
   {


### PR DESCRIPTION
This PR clarifies the instructions around running the first code cell in `week1/day1.ipynb`.

Changes:
- Update the intro paragraph so it no longer refers to a code cell "immediately below" when there isn't one.
- Add a short instruction in the markdown cell directly above the first code cell explaining to click the cell and press Shift+Return to run it.

No other content or behavior is changed.