### PR TITLE
Add LLM executive summary example notebook

### DIFF
--- a/community-contributions/nbogum/ea_assistant.ipynb
+++ b/community-contributions/nbogum/ea_assistant.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "52ad71db",
+   "metadata": {},
+   "source": [
+    "This LLM notebook example demonstrates a simple, practical use of LLM to translate the rough drafts of meeting notes into a concise one-page executive summary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea367241",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65787ef9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv('OPENAI_API_KEY')\n",
+    "\n",
+    "# Check the key\n",
+    "\n",
+    "if not api_key:\n",
+    "    print(\"No API key was found - please head over to the troubleshooting notebook in this folder to identify & fix!\")\n",
+    "elif not api_key.startswith(\"sk-proj-\"):\n",
+    "    print(\"An API key was found, but it doesn't start sk-proj-; please check you're using the right key - see troubleshooting notebook\")\n",
+    "elif api_key.strip() != api_key:\n",
+    "    print(\"An API key was found, but it looks like it might have space or tab characters at the start or end - please remove them - see troubleshooting notebook\")\n",
+    "else:\n",
+    "    print(\"API key found and looks good so far!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c4c568d",
+   "metadata": {},
+   "source": [
+    "Example meeting notes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baeac5c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOURCE_NOTES = \"\"\"\n",
+    "- App is old, monolith, runs on on-prem VMs, IIS + Windows\n",
+    "- Scaling issues during peak hours, especially month-end\n",
+    "- Deployments are painful, manual, require downtime\n",
+    "- Ops mentioned alerts come after users complain\n",
+    "- Logging scattered, some logs local, some in shared folders\n",
+    "\n",
+    "- Team wants to move to cloud (Azure or AWS), not decided yet\n",
+    "- Goal is infra + ops improvements first, not app rewrite\n",
+    "- Maybe break out some services later, but phase 1 = lift + stabilize\n",
+    "- Containers came up, AKS/EKS likely\n",
+    "- DB is SQL Server, big risk area, needs careful migration\n",
+    "\n",
+    "- CI/CD basically doesn’t exist right now\n",
+    "- People manually RDP and deploy\n",
+    "- Want automated pipelines, blue/green if possible\n",
+    "\n",
+    "- DR is weak, backups exist but no real DR testing\n",
+    "- Cloud should improve this but needs design\n",
+    "- Security team will need to review networking and access\n",
+    "\n",
+    "- Skills gap: team hasn’t used containers much\n",
+    "- Training or support needed\n",
+    "- Cost concern raised, don’t want surprise bills\n",
+    "\n",
+    "- High-level timeline thrown out:\n",
+    "  - Few weeks to assess/design\n",
+    "  - 2–3 months for initial platform + pilot\n",
+    "  - Rest of year to migrate fully\n",
+    "\n",
+    "- Open questions:\n",
+    "  - Azure vs AWS\n",
+    "  - SQL licensing\n",
+    "  - Who owns platform long-term\n",
+    "\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "790b0048",
+   "metadata": {},
+   "source": [
+    "Create Prompts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a85315ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"You are an enterprise architect's executive-summary assistant.\"\n",
+    "user_prompt = f\"\"\"\n",
+    "Create a one-page executive summary using the following template:\n",
+    "\n",
+    "Title\n",
+    "Purpose\n",
+    "Current State (3 bullets)\n",
+    "Proposed Approach (3 bullets)\n",
+    "Business Value (3 bullets)\n",
+    "Key Risks & Mitigations (3 bullets)\n",
+    "Decisions Needed (up to 3 bullets)\n",
+    "Next Steps / Timeline (3 bullets)\n",
+    "Open Questions (only if needed)\n",
+    "\n",
+    "Constraints:\n",
+    "- Max 550 words\n",
+    "- Short bullets (max 14 words each)\n",
+    "- Plain business language\n",
+    "- Do NOT invent facts or decisions\n",
+    "- Use only the information provided\n",
+    "\n",
+    "Source notes:\n",
+    "{SOURCE_NOTES}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aff7986f",
+   "metadata": {},
+   "source": [
+    "Create Open AI Cleint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8b993cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openai = OpenAI(api_key=api_key)"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
Adds `ea_assistant.ipynb`, a minimal Jupyter notebook demonstrating how an Enterprise Architect (EA) might use an LLM to convert rough meeting notes into a concise one-page executive summary.

## Context
In this notebook, “EA” refers to **Enterprise Architect**.  The example reflects a common EA workflow: synthesizing unstructured technical and architectural discussions into leadership-ready summaries.