### PR TITLE
Fixed Compiler error, The error occurs because tiktoken doesn't recog…

### DIFF
--- a/week5/day2.ipynb
+++ b/week5/day2.ipynb
@@ -100,7 +100,7 @@
    "source": [
     "# How many tokens in all the documents?\n",
     "\n",
-    "encoding = tiktoken.encoding_for_model(MODEL)\n",
+    "encoding = tiktoken.get_encoding(\"cl100k_base\")\n",
     "tokens = encoding.encode(entire_knowledge_base)\n",
     "token_count = len(tokens)\n",
     "print(f\"Total tokens for {MODEL}: {token_count:,}\")"


### PR DESCRIPTION
The error occurs because tiktoken doesn't recognize the model name "gpt-4.1-nano" in its internal mapping. You need to explicitly specify the encoding instead.
