### PR TITLE
added litellm in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,4 @@ sentence_transformers
 feedparser
 protobuf==3.20.2
 wandb
+litellm


### PR DESCRIPTION
I was getting  error in "from litellm import completion" then i added "litellm" in requirements and run pip install -r requirements.txt then it works fine 