### PR TITLE
Add ASIN-based Amazon Selenium scraper notebook

### DIFF
--- a/week1/community-contributions/harun_tx/week1_day1.ipynb
+++ b/week1/community-contributions/harun_tx/week1_day1.ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "25c9985d",
+   "metadata": {},
+   "source": [
+    "Notebook: Amazon Product Scraper (ASIN-based) — Selenium (amazon.com)\n",
+    "Cell 1 — Install dependencies (run once)\n",
+    "\n",
+    "If you already installed them and verified imports, you can skip this cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6950e30a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "print(\"Kernel Python:\", sys.executable)\n",
+    "\n",
+    "!{sys.executable} -m pip install -U pip\n",
+    "!{sys.executable} -m pip install -U selenium webdriver-manager\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db2d0bda",
+   "metadata": {},
+   "source": [
+    "Cell 2 — Verify installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "149eaf09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import selenium\n",
+    "from webdriver_manager.chrome import ChromeDriverManager\n",
+    "\n",
+    "print(\"selenium:\", selenium.__version__)\n",
+    "print(\"webdriver-manager: OK\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a10e02",
+   "metadata": {},
+   "source": [
+    "Cell 3 — Configuration (ASIN only)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12e8ec98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ASIN = \"B003R4Q7PS\"\n",
+    "\n",
+    "MARKETPLACE = \"amazon.com\"\n",
+    "PRODUCT_URL = f\"https://www.{MARKETPLACE}/dp/{ASIN}\"\n",
+    "\n",
+    "PRODUCT_URL\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0605dce",
+   "metadata": {},
+   "source": [
+    "Cell 4 — Imports (Selenium runtime)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d22dce29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from selenium import webdriver\n",
+    "from selenium.webdriver.chrome.service import Service\n",
+    "from selenium.webdriver.chrome.options import Options\n",
+    "from selenium.webdriver.common.by import By\n",
+    "from selenium.webdriver.support.ui import WebDriverWait\n",
+    "from selenium.webdriver.support import expected_conditions as EC\n",
+    "\n",
+    "import time\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93bc8766",
+   "metadata": {},
+   "source": [
+    "Cell 5 — Build the Chrome driver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26972ead",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_driver(headless: bool = False) -> webdriver.Chrome:\n",
+    "    options = Options()\n",
+    "\n",
+    "    # For Amazon, start with headless=False to reduce bot detection during development\n",
+    "    if headless:\n",
+    "        options.add_argument(\"--headless=new\")\n",
+    "\n",
+    "    # Reduce automation fingerprinting\n",
+    "    options.add_argument(\"--disable-blink-features=AutomationControlled\")\n",
+    "    options.add_argument(\"--window-size=1280,900\")\n",
+    "\n",
+    "    # Realistic User-Agent\n",
+    "    options.add_argument(\n",
+    "        \"user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) \"\n",
+    "        \"AppleWebKit/537.36 (KHTML, like Gecko) \"\n",
+    "        \"Chrome/120.0.0.0 Safari/537.36\"\n",
+    "    )\n",
+    "\n",
+    "    driver = webdriver.Chrome(\n",
+    "        service=Service(ChromeDriverManager().install()),\n",
+    "        options=options\n",
+    "    )\n",
+    "    return driver\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb3e7a77",
+   "metadata": {},
+   "source": [
+    "Cell 6 — Extract product data (title + bullets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be02dd4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def extract_amazon_product(driver: webdriver.Chrome, asin: str) -> dict:\n",
+    "    url = f\"https://www.amazon.com/dp/{asin}\"\n",
+    "    driver.get(url)\n",
+    "\n",
+    "    wait = WebDriverWait(driver, 25)\n",
+    "\n",
+    "    # 1) Title\n",
+    "    title_el = wait.until(EC.presence_of_element_located((By.ID, \"productTitle\")))\n",
+    "    title = title_el.text.strip()\n",
+    "\n",
+    "    # 2) Bullets\n",
+    "    bullets = []\n",
+    "    bullet_els = driver.find_elements(By.CSS_SELECTOR, \"#feature-bullets ul li span\")\n",
+    "\n",
+    "    for el in bullet_els:\n",
+    "        text = el.text.strip()\n",
+    "        if text and text.lower() not in {\"\", \"see more\"}:\n",
+    "            bullets.append(text)\n",
+    "\n",
+    "    # 3) Detect basic bot / captcha signals (best-effort)\n",
+    "    page_title = driver.title.lower()\n",
+    "    blocked = any(k in page_title for k in [\"robot\", \"captcha\", \"sorry\"])\n",
+    "\n",
+    "    return {\n",
+    "        \"asin\": asin,\n",
+    "        \"url\": url,\n",
+    "        \"title\": title,\n",
+    "        \"bullets\": bullets,\n",
+    "        \"blocked_suspected\": blocked,\n",
+    "        \"page_title\": driver.title\n",
+    "    }\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b8447da",
+   "metadata": {},
+   "source": [
+    "Cell 7 — Run the scraper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "179c2f27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "driver = build_driver(headless=False)\n",
+    "\n",
+    "try:\n",
+    "    product_data = extract_amazon_product(driver, ASIN)\n",
+    "finally:\n",
+    "    time.sleep(2)  # brief visual inspection window\n",
+    "    driver.quit()\n",
+    "\n",
+    "product_data\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3b7fab3",
+   "metadata": {},
+   "source": [
+    "Cell 8 — Pretty display in Jupyter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aae51f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "display(Markdown(f\"## {product_data['title']}\"))\n",
+    "display(Markdown(f\"**ASIN:** `{product_data['asin']}`\"))\n",
+    "display(Markdown(f\"**URL:** {product_data['url']}\"))\n",
+    "display(Markdown(f\"**Blocked suspected:** `{product_data['blocked_suspected']}`\"))\n",
+    "display(Markdown(\"---\"))\n",
+    "\n",
+    "display(Markdown(\"### Product Feature Bullets\"))\n",
+    "if product_data[\"bullets\"]:\n",
+    "    for b in product_data[\"bullets\"]:\n",
+    "        display(Markdown(f\"- {b}\"))\n",
+    "else:\n",
+    "    display(Markdown(\"_No bullets found (possible variation / blocked page / different layout)._\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1faa6f40",
+   "metadata": {},
+   "source": [
+    "Cell 9 — Batch mode (optional): scrape multiple ASINs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a5624df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ASIN_LIST = [\"B003R4Q7PS\", \"B00ZV9RDKK\"]  # replace with your list\n",
+    "\n",
+    "driver = build_driver(headless=False)\n",
+    "\n",
+    "results = []\n",
+    "try:\n",
+    "    for asin in ASIN_LIST:\n",
+    "        try:\n",
+    "            data = extract_amazon_product(driver, asin)\n",
+    "            results.append(data)\n",
+    "            time.sleep(2)  # polite delay\n",
+    "        except Exception as e:\n",
+    "            results.append({\"asin\": asin, \"error\": str(e)})\n",
+    "finally:\n",
+    "    driver.quit()\n",
+    "\n",
+    "results\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request adds a Jupyter notebook demonstrating an ASIN-based Amazon.com product scraper using Selenium.

### What’s included
- ASIN-parametric design (single input, reusable)
- Handles JavaScript-rendered Amazon product pages
- Extracts product title and feature bullet descriptions
- Clean, step-by-step notebook format suitable for learning and experimentation

### Notes
- Tested locally with Selenium 4.x and Chrome
- Notebook outputs are cleared for a clean diff
- No environment-specific lock files included
