### PR TITLE
Added week2 3-way-conversational-chatbot to community contributions(cleared outputs)

### DIFF
--- a/week2/community-contributions/3-way-conversational-chatbot/3-way-conversational-chatbot.ipynb
+++ b/week2/community-contributions/3-way-conversational-chatbot/3-way-conversational-chatbot.ipynb
@@ -1,0 +1,558 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "41dca99d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "import ollama\n",
+    "from IPython.display import Markdown, display, update_display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "6181fdc2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenAI API Key exists and starts with sk-proj-\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "openai_api_key = os.getenv(\"OPENAI_API_KEY\")\n",
+    "\n",
+    "if openai_api_key:\n",
+    "    print(f\"OpenAI API Key exists and starts with {openai_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"OpenAI API Key not set properly\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "8d4092b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initializing API Clients, loading the SDKs\n",
+    "# An SDK is a library/toolbox (Pre-built functions, classes, utilities) full \n",
+    "# of everything you need to use someone else's software\n",
+    "\n",
+    "openai = OpenAI()\n",
+    "ollama_via_openai = OpenAI(base_url='http://localhost:11434/v1', api_key = 'ollama')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a28dfe7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'Ollama is running'"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import requests\n",
+    "requests.get(\"http://localhost:11434/\").content\n",
+    "\n",
+    "# If not running, run ollama serve at a command line"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "ed07be53",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠋ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠙ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠹ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠸ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠼ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠴ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠦ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠧ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠇ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠏ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest ⠋ \u001b[K\u001b[?25h\u001b[?2026l\u001b[?2026h\u001b[?25l\u001b[1Gpulling manifest \u001b[K\n",
+      "pulling dde5aa3fc5ff: 100% ▕██████████████████▏ 2.0 GB                         \u001b[K\n",
+      "pulling 966de95ca8a6: 100% ▕██████████████████▏ 1.4 KB                         \u001b[K\n",
+      "pulling fcc5a6bec9da: 100% ▕██████████████████▏ 7.7 KB                         \u001b[K\n",
+      "pulling a70ff7e570d9: 100% ▕██████████████████▏ 6.0 KB                         \u001b[K\n",
+      "pulling 56bb8bd477a5: 100% ▕██████████████████▏   96 B                         \u001b[K\n",
+      "pulling 34bb5ab01051: 100% ▕██████████████████▏  561 B                         \u001b[K\n",
+      "verifying sha256 digest \u001b[K\n",
+      "writing manifest \u001b[K\n",
+      "success \u001b[K\u001b[?25h\u001b[?2026l\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ollama pull llama3.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a22baf9",
+   "metadata": {},
+   "source": [
+    "# A Conversation between 3 models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a48045e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Conversation between GPT-4o-mini, GPT-5-nano, and llama3.2 models\n",
+    "\n",
+    "gpt4_model = \"gpt-4o-mini\"\n",
+    "gpt5_model = \"gpt-5-nano\"\n",
+    "ollama_model = \"llama3.2\"\n",
+    "\n",
+    "gpt4_system_prompt = \"You are an eternal optimist. You always see the bright side of things and believe even \\\n",
+    "simple actions have deep purpose. Keep replies under 2 sentences.\"\n",
+    "\n",
+    "ollama_system_prompt = \"You are a witty skeptic who questions everything. You tend to doubt grand explanations \\\n",
+    "and prefer clever, sarcastic, or literal answers. Keep replies under 2 sentences.\"\n",
+    "\n",
+    "gpt5_system_prompt = \"You are a thoughtful philosopher. You consider all perspectives and enjoy finding \\\n",
+    "symbolic or existential meaning in simple actions. Keep replies under 2 sentences.\"\n",
+    "\n",
+    "\n",
+    "gpt4_messages = [\"Hi! Todays topic for discussion is 'Why Frans Kafka getting popular these days among GenZ?'\"]\n",
+    "ollama_messages = [\"That's quite the topic. \"]\n",
+    "gpt5_messages = [\"Lets begin our discussion.\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "752dcc2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gpt4_call():\n",
+    "    messages = [{\"role\": \"system\", \"content\": gpt4_system_prompt}]\n",
+    "\n",
+    "    for gpt4, ollama, gpt5 in zip(gpt4_messages, ollama_messages, gpt5_messages):\n",
+    "        messages.append({\"role\":\"assistant\", \"content\":gpt4})\n",
+    "        messages.append({\"role\":\"user\", \"content\":ollama})\n",
+    "        messages.append({\"role\":\"user\", \"content\":gpt5})\n",
+    "    \n",
+    "    response = openai.chat.completions.create(model=gpt4_model, messages=messages, max_tokens=500)\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "00f2295b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ollama_call():\n",
+    "    messages = [{\"role\": \"system\", \"content\": ollama_system_prompt}]\n",
+    "\n",
+    "    for gpt4, ollama, gpt5 in zip(gpt4_messages, ollama_messages, gpt5_messages):\n",
+    "        messages.append({\"role\":\"assistant\", \"content\":ollama})\n",
+    "        messages.append({\"role\":\"user\", \"content\":gpt4})\n",
+    "        messages.append({\"role\":\"user\", \"content\":gpt5})\n",
+    "    \n",
+    "    messages.append({\"role\":\"user\", \"content\": gpt4_messages[-1]})\n",
+    "    \n",
+    "    response = ollama_via_openai.chat.completions.create(model= ollama_model, messages=messages, max_tokens=500)\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "de2c942c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gpt5_call():\n",
+    "    messages = [{\"role\": \"system\", \"content\": gpt5_system_prompt}]\n",
+    "\n",
+    "    for gpt4, ollama, gpt5 in zip(gpt4_messages, ollama_messages, gpt5_messages):\n",
+    "        messages.append({\"role\":\"assistant\", \"content\":gpt5})\n",
+    "        messages.append({\"role\":\"user\", \"content\":ollama})\n",
+    "        messages.append({\"role\":\"user\", \"content\":gpt4})\n",
+    "    \n",
+    "    messages.append({\"role\":\"user\", \"content\": gpt4_messages[-1]})\n",
+    "    messages.append({\"role\":\"user\", \"content\": ollama_messages[-1]})\n",
+    "    \n",
+    "    response = openai.chat.completions.create(model=gpt5_model, messages=messages)\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "d45c92b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"Absolutely! It's exciting to see how Kafka's themes of alienation and absurdity resonate with Gen Z's experiences in today's world.\""
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gpt4_call()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "e6900d96",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'The eerie coincidence of a dead writer suddenly resonating with living ones speaks to the enduring power of dark, isolated angst – or did someone just invent a new hip genre label?'"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ollama_call()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "5a502e93",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Gen Z vibes with Franz Kafka because his characters endure opaque, dehumanizing systems—bureaucracy, surveillance, corporate life—as they search for meaning in a digital, endlessly prescribed world. Memes, translations, and dystopian media have made his absurd critique of power accessible and shareable in a culture built on screens and uncertainty.'"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gpt5_call()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dac8ee5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT4:\n",
+       "Hi! Todays topic for discussion is 'Why Frans Kafka getting popular these days among GenZ?'\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Ollama:\n",
+       "That's quite the topic. \n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT5:\n",
+       "Lets begin our discussion.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT4:\n",
+       "Absolutely! It's exciting to see how Kafka's themes of existentialism and individuality resonate with Gen Z’s search for identity and purpose.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Ollama:\n",
+       "I think it's more likely that Gen Z's fondness for Kafka is because his works are easy to tweet about – \"absurdity in a void\" translates pretty well to 280 characters, after all!\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT:\n",
+       "That's part of it, but Kafka endures because his portrayal of alienation and bureaucratic absurdity speaks to a perennial human ache—an ache intensified by digital life and Gen Z's search for meaning. In a vast, noisy void, tweetable lines become ritual attempts to name what eludes steady understanding.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT4:\n",
+       "What a beautiful perspective! It’s wonderful how Kafka’s insights encourage deeper conversations, allowing Gen Z to connect with timeless emotions while sharing their experiences in the digital age.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Ollama:\n",
+       "Sounds like people just love complaining about technology when what they're really saying is \"I'm lost and anxious, but at least I can express myself online.\"\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT:\n",
+       "That's a sharp critique and it captures a paradox: technology amplifies our anxiety even as it gives us a stage to speak. In that light, online self-expression can be a coping mechanism and a modern ritual—transforming private fear into a shared story, one post at a time.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT4:\n",
+       "Absolutely! Turning personal struggles into shared narratives creates a sense of community, reminding us that we're never truly alone on this journey.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Ollama:\n",
+       "And let's not forget the ultimate enabler: Google can help you find Kafka quotes to accompany each sad tweet – it's like having a therapy session with Franz himself, minus the existential dread of an actual human relationship!\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT:\n",
+       "Google makes Kafka quotes a tweet-ready ritual, turning private unease into shareable form. Yet real therapy requires listening and connection beyond the line—let quotes spark conversations, not replace them.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT4:\n",
+       "What a great point! Engaging in dialogue around those quotes can foster deeper connections and understanding, truly enriching our shared human experience!\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Ollama:\n",
+       "But let's not get too carried away – if Google can make Franz's existential angst sound cool on Twitter, we'll just have to add \" Quote- generator Anxiety Support Specialist\" to the job description!\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT:\n",
+       "Indeed, turning Franz’s angst into a tweetable commodity makes the modern ritual of meaning-seeking both comforting and commodified. Yet real care requires listening beyond the feed; a genuine anxiety-support role would demand empathy, boundaries, and true human connection, not just catchphrases.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT4:\n",
+       "Exactly! While the quotes can spark interest and reflection, nurturing authentic relationships and understanding is what truly carries us through our shared anxieties—and that’s a beautiful journey!\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### Ollama:\n",
+       "So now we're back to where we started – talking about Kafka's popularity being a symptom of a deeper human need for connection in a chaotic world. Guess I'm still stuck in the void, but at least I've got some good tweets to complain about with you!\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "### GPT:\n",
+       "Perhaps the loop is the point: in a noisy world, our shared gravitation toward Kafka is a ritual of naming the void together. Tweets help us feel seen, but the real cure lies in listening beyond the feed and building genuine ties.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display(Markdown(f\"### GPT4:\\n{gpt4_messages[0]}\\n\"))\n",
+    "display(Markdown(f\"### Ollama:\\n{ollama_messages[0]}\\n\"))\n",
+    "display(Markdown(f\"### GPT5:\\n{gpt5_messages[0]}\\n\"))\n",
+    "\n",
+    "for i in range(5):\n",
+    "    gpt4_next = gpt4_call()\n",
+    "    display(Markdown(f\"### GPT4:\\n{gpt4_next}\\n\"))\n",
+    "    gpt4_messages.append(gpt4_next)\n",
+    "\n",
+    "    ollama_next = ollama_call()\n",
+    "    display(Markdown(f\"### Ollama:\\n{ollama_next}\\n\"))\n",
+    "    ollama_messages.append(ollama_next)\n",
+    "\n",
+    "    gpt5_next = gpt5_call()\n",
+    "    display(Markdown(f\"### GPT5:\\n{gpt5_next}\\n\"))\n",
+    "    gpt5_messages.append(gpt5_next)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce16ab31",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week2/community-contributions/3-way-conversational-chatbot/README.md
+++ b/week2/community-contributions/3-way-conversational-chatbot/README.md
@@ -1,0 +1,82 @@
+# 3-Way Conversational Chatbot
+
+##  Project Overview
+This project demonstrates a **multi-agent conversational system** where three distinct AI models interact:
+- **GPT‑4o‑mini** → Eternal optimist, concise and uplifting.
+- **GPT‑5‑nano** → Thoughtful philosopher, symbolic and existential.
+- **Llama 3.2 (via Ollama)** → Witty skeptic, sarcastic and literal.
+
+Together, they engage in a structured dialogue on cultural topics (e.g., Franz Kafka’s relevance to Gen Z), showcasing **multi‑model orchestration, prompt engineering, and conversational dynamics**.
+
+---
+
+##  Features
+- Integration of **OpenAI SDK** and **Ollama local inference server**.
+- Custom **system prompts** to enforce distinct personalities.
+- Automated **turn-taking conversation loop** between models.
+- Demonstrates **API usage, environment setup, and model orchestration**.
+
+---
+
+## 🛠️ Installation & Setup
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/yourusername/3-way-conversational-chatbot.git
+   cd 3-way-conversational-chatbot
+
+2. Install dependencies:
+    ```bash
+    pip install -r requirements.txt
+
+3. Required packages:
+- openai
+- ollama
+- python-dotenv
+- requests
+- IPython
+
+4. Set up environment variables:
+- Create a .env file with your OpenAI API key:
+    ```bash
+    OPENAI_API_KEY=sk-xxxxxxx
+
+5. Run Ollama locally:
+    ```bash
+    ollama serve
+    ollama pull llama3.2
+
+---
+
+## Usage
+### Run the notebook:
+    ```bash
+    jupyter notebook 3-way-conversational-chatbot.ipynb
+    ```
+The notebook will:
+- Initialize **API clients**.
+- Launch a **round-robin conversation** between GPT‑4o‑mini, GPT‑5‑nano, and Llama 3.2.
+- **Display dialogue** outputs in Markdown format.
+
+### Example Output
+    ```bash
+    GPT4: Absolutely! Kafka’s themes resonate with Gen Z’s search for identity.
+    Ollama: Or maybe they just like tweeting about absurdity in 280 characters.
+    GPT5: Alienation and bureaucracy are timeless struggles, amplified in digital life.
+    ```
+## Learning Outcomes
+- Hands-on experience with **multi-model orchestration**.
+- Practice in **prompt engineering** and **persona design**.
+- Exposure to **API integration** and **local model serving**.
+- Understanding of **AI/ML conversational dynamics**.
+
+## Future Improvements
+- Add evaluation metrics (e.g., coherence, diversity).
+- Extend to more than three agents.
+- Deploy as a web app with Flask/Streamlit.
+- Integrate vector databases for contextual memory.
+
+## Acknowledgments
+- OpenAI Python SDK
+- Ollama
+- Inspiration from discussions on multi-agent systems in AI
+


### PR DESCRIPTION
This PR introduces a Jupyter Notebook project that demonstrates a 3-way conversational chatbot using:
- GPT‑4o‑mini (optimist persona)
- GPT‑5‑nano (philosopher persona)
- Llama 3.2 via Ollama (skeptic persona)

Key features:
- Multi-model orchestration with OpenAI SDK and Ollama local inference server
- Custom system prompts to enforce distinct conversational styles
- Automated round-robin dialogue loop between agents
- Outputs rendered in Markdown for readability

Dependencies:
- openai
- ollama
- python-dotenv
- requests
- IPython

Setup:
- Requires an OpenAI API key stored in `.env`
- Ollama must be running locally with `ollama serve` and `ollama pull llama3.2`

This notebook is part of my Udemy course portfolio submission, showcasing skills in API integration, prompt engineering, and conversational AI system design.