### PR TITLE
Type kwarg in Gradio is deprecated, it's time to remove it!

### DIFF
--- a/week2/day3.ipynb
+++ b/week2/day3.ipynb
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gr.ChatInterface(fn=chat, ).launch()"
+    "gr.ChatInterface(fn=chat).launch()"
    ]
   },
   {
@@ -124,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gr.ChatInterface(fn=chat, ).launch()"
+    "gr.ChatInterface(fn=chat).launch()"
    ]
   },
   {
@@ -227,7 +227,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gr.ChatInterface(fn=chat, ).launch()"
+    "gr.ChatInterface(fn=chat).launch()"
    ]
   },
   {
@@ -248,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gr.ChatInterface(fn=chat, ).launch()"
+    "gr.ChatInterface(fn=chat).launch()"
    ]
   },
   {
@@ -282,7 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gr.ChatInterface(fn=chat, ).launch()"
+    "gr.ChatInterface(fn=chat).launch()"
    ]
   },
   {


### PR DESCRIPTION
Latest versions of gradio causes runtime error when type kwarg is included, please do apply this change