### PR TITLE
Added a feature for website comparison on the summarizer of day 1 project

### DIFF
--- a/week1/community-contributions/website-comparison-agent/day1.ipynb
+++ b/week1/community-contributions/website-comparison-agent/day1.ipynb
@@ -429,7 +429,7 @@
    "source": [
     "# Try this out, and then try for a few more websites\n",
     "\n",
-    "messages_for(ed)"
+    "messages_for(\"https://youtube.com\", \"https://ebay.com\")"
    ]
   },
   {
@@ -466,7 +466,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "summarize(\"https://youtube.com\", \"ebay.com\")"
+    "summarize(\"https://youtube.com\", \"https://ebay.com\")"
    ]
   },
   {


### PR DESCRIPTION
In this PR I have tweaked the summarize function to have the option to obtain two different urls and would be instructed to create a table of comparison between citing their primary focus, feature type, and more.