### PR TITLE
Add benchmark module with streaming metrics, auto timing, and stale file detection for week 4 day 3

### DIFF
--- a/week4/community-contributions/Himesh/benchmark.py
+++ b/week4/community-contributions/Himesh/benchmark.py
@@ -1,0 +1,249 @@
+"""
+Benchmark: Port Python → C++ via LLMs and compare execution times.
+
+Usage in notebook:
+    from benchmark import benchmark_models
+    
+    models = {
+        "GPT-5 Nano":       "openai/gpt-5-nano",
+        "Claude 3.5 Haiku": "anthropic/claude-3.5-haiku",
+    }
+    results = benchmark_models(openrouter, models, pi, compile_command, run_command, system_info=system_info)
+"""
+
+import hashlib
+import io
+import os
+import re
+import subprocess
+import sys
+import time
+
+
+# ── Prompts ──────────────────────────────────────────────────────────────────
+
+SYSTEM_PROMPT = """
+Your task is to convert Python code into high performance C++ code.
+Respond only with C++ code. Do not provide any explanation other than occasional comments.
+The C++ response needs to produce an identical output in the fastest possible time.
+"""
+
+
+def _user_prompt(python: str, system_info: dict, compile_cmd: list[str]) -> str:
+    return f"""
+Port this Python code to C++ with the fastest possible implementation that produces identical output in the least time.
+The system information is:
+{system_info}
+Your response will be written to a file called main.cpp and then compiled and executed; the compilation command is:
+{compile_cmd}
+Respond only with C++ code.
+Python code to port:
+
+```python
+{python}
+```
+"""
+
+
+# ── Python Baseline ─────────────────────────────────────────────────────────
+
+def run_python(code: str) -> float:
+    """Execute Python code, capture stdout, and parse the execution time.
+    
+    Returns execution time in seconds.
+    Raises ValueError if time cannot be parsed from output.
+    """
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        exec(code, {"__builtins__": __builtins__})
+    finally:
+        sys.stdout = old_stdout
+
+    output = captured.getvalue()
+    print(output, end="")  # echo to notebook
+
+    match = re.search(r"Execution Time:\s*([\d.]+)\s*seconds", output)
+    if not match:
+        raise ValueError(f"Could not parse execution time from Python output:\n{output}")
+    return float(match.group(1))
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _file_hash(path: str) -> str:
+    """Return MD5 hex digest of a file, or empty string if file doesn't exist."""
+    if not os.path.exists(path):
+        return ""
+    with open(path, "rb") as f:
+        return hashlib.md5(f.read()).hexdigest()
+
+
+# ── Core Functions ───────────────────────────────────────────────────────────
+
+def port(client, model: str, python: str, system_info: dict = None, compile_cmd: list[str] = None) -> dict:
+    """Call LLM via streaming to port Python → C++.
+    
+    Returns dict with keys: cpp_code, ttft, generation_time, file_changed.
+    Raises on any API error.
+    """
+    kwargs = {}
+    
+    kwargs["reasoning_effort"] = "high"
+
+    old_hash = _file_hash("main.cpp")
+
+    # Stream to measure TTFT and total generation time
+    t_start = time.time()
+    ttft = None
+    chunks = []
+
+    stream = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": _user_prompt(python, system_info or {}, compile_cmd or [])},
+        ],
+        stream=True,
+        **kwargs,
+    )
+
+    for chunk in stream:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta and delta.content:
+            if ttft is None:
+                ttft = time.time() - t_start
+            chunks.append(delta.content)
+
+    generation_time = time.time() - t_start
+
+    cpp_code = "".join(chunks)
+    cpp_code = cpp_code.replace("```cpp", "").replace("```", "").strip()
+
+    if not cpp_code:
+        raise ValueError(f"Model {model} returned empty response")
+
+    with open("main.cpp", "w", encoding="utf-8") as f:
+        f.write(cpp_code)
+
+    new_hash = _file_hash("main.cpp")
+    file_changed = new_hash != old_hash
+
+    return {
+        "cpp_code": cpp_code,
+        "ttft": ttft or 0.0,
+        "generation_time": generation_time,
+        "file_changed": file_changed,
+        "file_size": len(cpp_code),
+    }
+
+
+def compile_and_run(compile_cmd: list[str], run_cmd: list[str], runs: int = 3) -> dict:
+    """Compile main.cpp, run it `runs` times, parse and return timing stats."""
+    subprocess.run(compile_cmd, check=True, text=True, capture_output=True)
+
+    times = []
+    outputs = []
+    for i in range(runs):
+        result = subprocess.run(run_cmd, check=True, text=True, capture_output=True)
+        outputs.append(result.stdout.strip())
+
+        match = re.search(r"Execution Time:\s*([\d.]+)\s*seconds", result.stdout)
+        if match:
+            times.append(float(match.group(1)))
+
+    return {
+        "times": times,
+        "avg": sum(times) / len(times) if times else None,
+        "min": min(times) if times else None,
+        "max": max(times) if times else None,
+        "outputs": outputs,
+    }
+
+
+def port_and_benchmark(
+    client, model: str, python: str, compile_cmd: list[str], run_cmd: list[str],
+    system_info: dict = None, runs: int = 3
+) -> dict:
+    """Port Python→C++ via model, compile, run, and return benchmark results.
+    
+    Raises on API errors so stale main.cpp is never used.
+    """
+    print(f"🔄 Porting with {model}...")
+    port_info = port(client, model, python, system_info, compile_cmd)
+
+    print(f"   TTFT:       {port_info['ttft']:.2f}s")
+    print(f"   Generation: {port_info['generation_time']:.2f}s")
+    print(f"   File size:  {port_info['file_size']} bytes")
+    if not port_info["file_changed"]:
+        print("   ⚠️  WARNING: main.cpp content unchanged from previous model!")
+
+    print(f"⚙️  Compiling & running {runs}x...")
+    stats = compile_and_run(compile_cmd, run_cmd, runs)
+
+    print(f"✅ {model}")
+    for i, t in enumerate(stats["times"]):
+        print(f"   Run {i+1}: {t:.6f}s")
+    print(f"   Avg:   {stats['avg']:.6f}s")
+
+    return {"model": model, **stats, **port_info}
+
+
+# ── Multi-Model Comparison ───────────────────────────────────────────────────
+
+def benchmark_models(
+    client, models: dict[str, str], python: str,
+    compile_cmd: list[str], run_cmd: list[str],
+    system_info: dict = None, runs: int = 3
+):
+    """Run Python baseline, benchmark all models, and print a comparison table.
+    
+    Args:
+        client:       OpenAI-compatible client
+        models:       dict of {display_name: model_id}
+        python:       Python source code to port
+        compile_cmd:  Compilation command list
+        run_cmd:      Run command list
+        system_info:  System info dict (optional)
+        runs:         Number of runs per model
+    
+    Returns:
+        list of result dicts, sorted by avg time (fastest first)
+    """
+    # ── Python baseline ──
+    print("🐍 Running Python baseline...")
+    python_time = run_python(python)
+    print(f"   Python time: {python_time:.6f}s\n")
+
+    # ── Benchmark each model ──
+    results = []
+    for name, model_id in models.items():
+        try:
+            result = port_and_benchmark(client, model_id, python, compile_cmd, run_cmd, system_info, runs)
+            result["name"] = name
+            results.append(result)
+        except Exception as e:
+            print(f"❌ {name} ({model_id}) FAILED: {e}")
+            results.append({"name": name, "model": model_id, "avg": None, "error": str(e)})
+        print()
+
+    # Sort by avg time (failures last)
+    results.sort(key=lambda r: r["avg"] if r["avg"] is not None else float("inf"))
+
+    # ── Summary table ──
+    print("=" * 90)
+    print(f"{'Rank':<5} {'Model':<30} {'Avg (s)':<12} {'Speedup':<10} {'TTFT':<10} {'Gen Time'}")
+    print("-" * 90)
+    for i, r in enumerate(results, 1):
+        if r["avg"] is not None:
+            speedup = python_time / r["avg"]
+            ttft = f"{r.get('ttft', 0):.2f}s"
+            gen = f"{r.get('generation_time', 0):.2f}s"
+            print(f"{i:<5} {r['name']:<30} {r['avg']:<12.6f} {speedup:<10.0f}X {ttft:<10} {gen}")
+        else:
+            print(f"{i:<5} {r['name']:<30} {'FAILED':<12} {'-':<10} {'-':<10} -")
+    print("=" * 90)
+    print(f"Python baseline: {python_time:.6f}s")
+
+    return results

--- a/week4/community-contributions/Himesh/day3.ipynb
+++ b/week4/community-contributions/Himesh/day3.ipynb
@@ -1,0 +1,267 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3822015c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "import subprocess\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1e60448a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from benchmark import port_and_benchmark, benchmark_models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d5c430ba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Openrouter API Key exists and begins sk-or-v1\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "openrouter_base_url, openrouter_api_key = os.getenv('OPENROUTER_BASE_URL'), os.getenv('OPENROUTER_API_KEY')\n",
+    "\n",
+    "if openrouter_api_key:\n",
+    "    print(f\"Openrouter API Key exists and begins {openrouter_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"Openrouter API Key not set\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cb80bd9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect to client libraries\n",
+    "openrouter = OpenAI(base_url=openrouter_base_url, api_key=openrouter_api_key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d57b9c52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OPENAI_MODEL = \"openai/gpt-5-nano\"\n",
+    "CLAUDE_MODEL = \"anthropic/claude-3.5-haiku\"\n",
+    "GROK_MODEL = \"x-ai/grok-4.1-fast\"\n",
+    "GEMINI_MODEL = \"google/gemini-2.5-flash-lite-preview-09-2025\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8d2724b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'os': {'system': 'Windows',\n",
+       "  'arch': 'AMD64',\n",
+       "  'release': '11',\n",
+       "  'version': '10.0.26200',\n",
+       "  'kernel': '11',\n",
+       "  'distro': None,\n",
+       "  'wsl': False,\n",
+       "  'rosetta2_translated': False,\n",
+       "  'target_triple': 'mingw32'},\n",
+       " 'package_managers': ['winget'],\n",
+       " 'cpu': {'brand': '12th Gen Intel(R) Core(TM) i9-12900H',\n",
+       "  'cores_logical': 20,\n",
+       "  'cores_physical': 14,\n",
+       "  'simd': []},\n",
+       " 'toolchain': {'compilers': {'gcc': 'gcc.exe (MinGW.org GCC-6.3.0-1) 6.3.0',\n",
+       "   'g++': 'g++.exe (MinGW.org GCC-6.3.0-1) 6.3.0',\n",
+       "   'clang': '',\n",
+       "   'msvc_cl': ''},\n",
+       "  'build_tools': {'cmake': '', 'ninja': '', 'make': ''},\n",
+       "  'linkers': {'ld_lld': ''}}}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from system_info import retrieve_system_info\n",
+    "\n",
+    "system_info = retrieve_system_info()\n",
+    "system_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "26d6ba8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pi = \"\"\"\n",
+    "import time\n",
+    "\n",
+    "def calculate(iterations, param1, param2):\n",
+    "    result = 1.0\n",
+    "    for i in range(1, iterations+1):\n",
+    "        j = i * param1 - param2\n",
+    "        result -= (1/j)\n",
+    "        j = i * param1 + param2\n",
+    "        result += (1/j)\n",
+    "    return result\n",
+    "\n",
+    "start_time = time.time()\n",
+    "result = calculate(200_000_000, 4, 1) * 4\n",
+    "end_time = time.time()\n",
+    "\n",
+    "print(f\"Result: {result:.12f}\")\n",
+    "print(f\"Execution Time: {(end_time - start_time):.6f} seconds\")\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4f8ba6a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compile_command = [\"g++\", \"-std=c++17\", \"-O3\", \"main.cpp\", \"-o\", \"main.exe\"]\n",
+    "run_command = [\"./main\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1d7d5b5a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🐍 Running Python baseline...\n",
+      "Result: 3.141592656089\n",
+      "Execution Time: 95.853235 seconds\n",
+      "   Python time: 95.853235s\n",
+      "\n",
+      "🔄 Porting with openai/gpt-5-nano...\n",
+      "   TTFT:       133.25s\n",
+      "   Generation: 133.49s\n",
+      "   File size:  867 bytes\n",
+      "⚙️  Compiling & running 3x...\n",
+      "✅ openai/gpt-5-nano\n",
+      "   Run 1: 1.305619s\n",
+      "   Run 2: 1.287392s\n",
+      "   Run 3: 1.287194s\n",
+      "   Avg:   1.293402s\n",
+      "\n",
+      "🔄 Porting with anthropic/claude-3.5-haiku...\n",
+      "   TTFT:       1.90s\n",
+      "   Generation: 5.15s\n",
+      "   File size:  837 bytes\n",
+      "⚙️  Compiling & running 3x...\n",
+      "✅ anthropic/claude-3.5-haiku\n",
+      "   Run 1: 1.243624s\n",
+      "   Run 2: 1.294883s\n",
+      "   Run 3: 1.279758s\n",
+      "   Avg:   1.272755s\n",
+      "\n",
+      "🔄 Porting with x-ai/grok-4.1-fast...\n",
+      "   TTFT:       46.76s\n",
+      "   Generation: 47.69s\n",
+      "   File size:  705 bytes\n",
+      "⚙️  Compiling & running 3x...\n",
+      "✅ x-ai/grok-4.1-fast\n",
+      "   Run 1: 1.233298s\n",
+      "   Run 2: 1.233978s\n",
+      "   Run 3: 1.235738s\n",
+      "   Avg:   1.234338s\n",
+      "\n",
+      "🔄 Porting with google/gemini-2.5-flash-lite-preview-09-2025...\n",
+      "   TTFT:       15.74s\n",
+      "   Generation: 18.54s\n",
+      "   File size:  2134 bytes\n",
+      "⚙️  Compiling & running 3x...\n",
+      "✅ google/gemini-2.5-flash-lite-preview-09-2025\n",
+      "   Run 1: 1.251962s\n",
+      "   Run 2: 1.248883s\n",
+      "   Run 3: 1.256767s\n",
+      "   Avg:   1.252537s\n",
+      "\n",
+      "==========================================================================================\n",
+      "Rank  Model                          Avg (s)      Speedup    TTFT       Gen Time\n",
+      "------------------------------------------------------------------------------------------\n",
+      "1     Grok 4.1 Fast                  1.234338     78        X 46.76s     47.69s\n",
+      "2     Gemini 2.5 Flash               1.252537     77        X 15.74s     18.54s\n",
+      "3     Claude 3.5 Haiku               1.272755     75        X 1.90s      5.15s\n",
+      "4     GPT-5 Nano                     1.293402     74        X 133.25s    133.49s\n",
+      "==========================================================================================\n",
+      "Python baseline: 95.853235s\n"
+     ]
+    }
+   ],
+   "source": [
+    "from benchmark import benchmark_models\n",
+    "\n",
+    "models = {\n",
+    "    \"GPT-5 Nano\":       OPENAI_MODEL,\n",
+    "    \"Claude 3.5 Haiku\": CLAUDE_MODEL,\n",
+    "    \"Grok 4.1 Fast\":    GROK_MODEL,\n",
+    "    \"Gemini 2.5 Flash\": GEMINI_MODEL,\n",
+    "}\n",
+    "\n",
+    "results = benchmark_models(\n",
+    "    openrouter, models, pi,\n",
+    "    compile_command, run_command,\n",
+    "    system_info=system_info\n",
+    ")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
@ed-donner 

Replaced the scattered port/compile/average cells in day3 with a single benchmark.py module for week 4 day 3 jupyter notebook

- Auto-measures Python baseline time instead of hardcoding it
- Uses streaming to track TTFT and total generation time per model
- Hashes main.cpp before/after each model to catch stale responses
- Raises on API errors instead of silently reusing old main.cpp
- Prints a ranked comparison table with speedups at the end

<img width="369" height="794" alt="image" src="https://github.com/user-attachments/assets/b857b583-81c8-4e1c-ad51-e03f54e30e70" />
<img width="664" height="801" alt="image" src="https://github.com/user-attachments/assets/55005c38-2536-4395-8aab-303a78af1720" />
