### PR TITLE
Fix MemoryError when pushing large datasets to Hugging Face Hub

### DIFF
--- a/week6/pricer/items.py
+++ b/week6/pricer/items.py
@@ -35,9 +35,9 @@ class Item(BaseModel):
         """Push Item lists to HuggingFace Hub"""
         DatasetDict(
             {
-                "train": Dataset.from_list([item.model_dump() for item in train]),
-                "validation": Dataset.from_list([item.model_dump() for item in val]),
-                "test": Dataset.from_list([item.model_dump() for item in test]),
+                "train": Dataset.from_generator(lambda: (item.model_dump() for item in train)),
+                "validation": Dataset.from_generator(lambda: (item.model_dump() for item in val)),
+                "test": Dataset.from_generator(lambda: (item.model_dump() for item in test)),
             }
         ).push_to_hub(dataset_name)
 


### PR DESCRIPTION
This MR addresses the `MemoryError` encountered when pushing large datasets to the Hugging Face Hub (see #3150).

Previously, the implementation used `Dataset.from_list()`, which required materializing the entire dataset in memory before conversion to an Arrow table. This caused excessive memory usage and failures for large datasets (~800k+ rows).

## Changes
- Replaced `Dataset.from_list()` with `Dataset.from_generator()` for all splits:
  - train
  - validation
  - test
- Eliminated the need to create large intermediate Python lists
- Enabled more memory-efficient dataset construction

Updated implementation:
```py
@staticmethod
def push_to_hub(dataset_name: str, train, val, test):
    ds = DatasetDict({
        "train": Dataset.from_generator(lambda: (item.model_dump() for item in train)),
        "validation": Dataset.from_generator(lambda: (item.model_dump() for item in val)),
        "test": Dataset.from_generator(lambda: (item.model_dump() for item in test)),
    })
    ds.push_to_hub(dataset_name)
```

## Benefits
- Reduces peak memory usage during dataset creation
- Avoids MemoryError for large datasets
- Keeps implementation simple and minimal

## Impact
- No changes to dataset structure or schema
- Fully backward compatible
- Only affects internal dataset construction logic

## Testing
- Verified dataset upload completes without MemoryError on large datasets
- Confirmed all splits are correctly pushed to the Hub

## Linked Issue
Fixes #3150