### PR TITLE
Add football results analyser with Selenium + OpenAI (gilbert-mutai)

### DIFF
--- a/week1/community-contributions/gilbert-mutai/.gitignore
+++ b/week1/community-contributions/gilbert-mutai/.gitignore
@@ -1,0 +1,6 @@
+.env
+__pycache__/
+*.csv
+*.xlsx
+*.pdf
+.ipynb_checkpoints/

--- a/week1/community-contributions/gilbert-mutai/football_results.ipynb
+++ b/week1/community-contributions/gilbert-mutai/football_results.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0000-0000-000000000001",
+   "metadata": {},
+   "source": [
+    "# Football Results Analyser\n",
+    "\n",
+    "This notebook scrapes recent match results from **Flashscore.com** across multiple leagues using Selenium (required because the site is fully JavaScript-rendered \u2014 plain `requests` won't work), then feeds the data to an OpenAI model for a narrative analysis.\n",
+    "\n",
+    "**Leagues covered:** EPL \u00b7 La Liga \u00b7 Bundesliga\n",
+    "\n",
+    "**What it demonstrates:**\n",
+    "- Selenium for JS-heavy sites (addresses the limitation called out in `day1.ipynb`)\n",
+    "- Structuring scraped data as a pandas DataFrame before passing to an LLM\n",
+    "- Using a system prompt to steer the tone of analysis\n",
+    "- Displaying LLM output as rendered Markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0002-0000-0000-000000000002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0003-0000-0000-000000000003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0004-0000-0000-000000000004",
+   "metadata": {},
+   "source": [
+    "## Step 1 \u2014 Scrape results\n",
+    "\n",
+    "The scraper runs a headless Chrome browser, dismisses the cookie banner, and waits for the match elements to load before extracting them. Set `headless=False` if you want to watch it work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0005-0000-0000-000000000005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scraper import scrape_all_leagues\n",
+    "\n",
+    "rows = scrape_all_leagues(headless=True)\n",
+    "df = pd.DataFrame(rows, columns=['league', 'date', 'home_team', 'score', 'away_team'])\n",
+    "print(f'Total matches scraped: {len(df)}')\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0006-0000-0000-000000000006",
+   "metadata": {},
+   "source": [
+    "## Step 2 \u2014 Results per league"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0007-0000-0000-000000000007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for league, group in df.groupby('league', sort=False):\n",
+    "    print(f'\\n=== {league} ({len(group)} matches) ===')\n",
+    "    print(group[['date', 'home_team', 'score', 'away_team']].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000008",
+   "metadata": {},
+   "source": [
+    "## Step 3 \u2014 LLM Analysis\n",
+    "\n",
+    "We format the full results table as plain text and ask GPT to identify standout results, upsets, and scoring trends across all leagues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0009-0000-0000-000000000009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are an expert football analyst covering European football.\n",
+    "You will be given a batch of recent match results from multiple leagues.\n",
+    "Your job is to write a concise, insightful analysis that covers:\n",
+    "- The most surprising upsets or high-scoring games\n",
+    "- Any team that looks to be in outstanding or poor form\n",
+    "- A brief cross-league comparison of attacking play (goals per game)\n",
+    "Write in an engaging style. Respond in Markdown. Do not wrap the markdown in a code block.\n",
+    "\"\"\"\n",
+    "\n",
+    "def build_results_text(df):\n",
+    "    lines = []\n",
+    "    for league, group in df.groupby('league', sort=False):\n",
+    "        lines.append(f'### {league}')\n",
+    "        for _, row in group.iterrows():\n",
+    "            lines.append(f\"  {row['date']}  {row['home_team']} {row['score']} {row['away_team']}\")\n",
+    "        lines.append('')\n",
+    "    return '\\n'.join(lines)\n",
+    "\n",
+    "def analyse_results(df):\n",
+    "    results_text = build_results_text(df)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model='gpt-4.1-mini',\n",
+    "        messages=[\n",
+    "            {'role': 'system', 'content': system_prompt},\n",
+    "            {'role': 'user', 'content': f'Here are the latest results:\\n\\n{results_text}'}\n",
+    "        ]\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0010-0000-0000-000000000010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis = analyse_results(df)\n",
+    "display(Markdown(analysis))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0011-0000-0000-000000000011",
+   "metadata": {},
+   "source": [
+    "## Step 4 \u2014 Per-league breakdown\n",
+    "\n",
+    "Ask the model to focus on one league at a time for a deeper read."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0012-0000-0000-000000000012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def analyse_league(df, league_name):\n",
+    "    league_df = df[df['league'] == league_name]\n",
+    "    if league_df.empty:\n",
+    "        print(f'No data for {league_name}')\n",
+    "        return\n",
+    "    results_text = build_results_text(league_df)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model='gpt-4.1-mini',\n",
+    "        messages=[\n",
+    "            {'role': 'system', 'content': system_prompt},\n",
+    "            {'role': 'user', 'content': f'Focus only on {league_name}. Here are the results:\\n\\n{results_text}'}\n",
+    "        ]\n",
+    "    )\n",
+    "    display(Markdown(response.choices[0].message.content))\n",
+    "\n",
+    "analyse_league(df, 'EPL')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0013-0000-0000-000000000013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analyse_league(df, 'La Liga')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0014-0000-0000-000000000014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analyse_league(df, 'Bundesliga')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0015-0000-0000-000000000015",
+   "metadata": {},
+   "source": [
+    "## Extending this notebook\n",
+    "\n",
+    "Some ideas to take this further:\n",
+    "\n",
+    "- **Add more leagues** \u2014 extend the `LEAGUES` dict in `scraper.py` with Serie A, Ligue 1, etc.\n",
+    "- **Predict upcoming fixtures** \u2014 scrape the fixtures page instead of results and ask GPT to predict outcomes\n",
+    "- **Track form over time** \u2014 run the scraper on a schedule and store results in a CSV to feed the model historical context\n",
+    "- **Export the analysis** \u2014 pipe the Markdown output into the PDF generator from the original project"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week1/community-contributions/gilbert-mutai/requirements.txt
+++ b/week1/community-contributions/gilbert-mutai/requirements.txt
@@ -1,0 +1,7 @@
+selenium>=4.0.0
+webdriver-manager>=4.0.0
+pandas>=2.0.0
+openpyxl>=3.1.0
+fpdf2>=2.7.0
+openai>=1.0.0
+python-dotenv>=1.0.0

--- a/week1/community-contributions/gilbert-mutai/scraper.py
+++ b/week1/community-contributions/gilbert-mutai/scraper.py
@@ -1,0 +1,76 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+
+LEAGUES = {
+    'EPL':        'https://www.flashscore.com/football/england/premier-league/results/',
+    'La Liga':    'https://www.flashscore.com/football/spain/laliga/results/',
+    'Bundesliga': 'https://www.flashscore.com/football/germany/bundesliga/results/',
+}
+
+
+def setup_driver(headless=True):
+    options = Options()
+    if headless:
+        options.add_argument('--headless=new')
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--window-size=1920,1080')
+    driver = webdriver.Chrome(
+        service=ChromeService(ChromeDriverManager().install()),
+        options=options,
+    )
+    return driver
+
+
+def dismiss_cookie_banner(driver):
+    try:
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable((By.ID, 'onetrust-accept-btn-handler'))
+        ).click()
+        time.sleep(0.5)
+    except Exception:
+        pass
+
+
+def scrape_league(driver, league_name, url):
+    print(f'Scraping {league_name} ...')
+    driver.get(url)
+
+    dismiss_cookie_banner(driver)
+
+    WebDriverWait(driver, 15).until(
+        EC.presence_of_all_elements_located((By.CSS_SELECTOR, '[class*="event__match"]'))
+    )
+
+    rows = []
+    matches = driver.find_elements(By.CSS_SELECTOR, '[class*="event__match"]')
+    for match in matches:
+        try:
+            date  = match.find_element(By.CSS_SELECTOR, '.event__time').text
+            home  = match.find_element(By.CSS_SELECTOR, '[class*="event__homeParticipant"] [class*="wcl-name"]').text
+            away  = match.find_element(By.CSS_SELECTOR, '[class*="event__awayParticipant"] [class*="wcl-name"]').text
+            goals = match.find_elements(By.CSS_SELECTOR, '[class*="event__score"]')
+            score = f'{goals[0].text} - {goals[1].text}' if len(goals) >= 2 else 'vs'
+            rows.append({'league': league_name, 'date': date, 'home_team': home, 'score': score, 'away_team': away})
+        except Exception:
+            continue
+
+    print(f'  → {len(rows)} matches found')
+    return rows
+
+
+def scrape_all_leagues(headless=True):
+    driver = setup_driver(headless=headless)
+    all_rows = []
+    try:
+        for league_name, url in LEAGUES.items():
+            all_rows.extend(scrape_league(driver, league_name, url))
+    finally:
+        driver.quit()
+    return all_rows


### PR DESCRIPTION
Scrapes EPL, La Liga, and Bundesliga results from Flashscore.com using headless Selenium (required for JS-rendered pages), then feeds the data to gpt-4.1-mini for cross-league analysis and per-league breakdowns.