### PR TITLE
Add football results analyser with Selenium + OpenAI (gilbert-mutai)

### DIFF
--- a/week1/community-contributions/gilbert-mutai/.gitignore
+++ b/week1/community-contributions/gilbert-mutai/.gitignore
@@ -1,0 +1,6 @@
+.env
+__pycache__/
+*.csv
+*.xlsx
+*.pdf
+.ipynb_checkpoints/

--- a/week1/community-contributions/gilbert-mutai/football_results.ipynb
+++ b/week1/community-contributions/gilbert-mutai/football_results.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0000-0000-000000000001",
+   "metadata": {},
+   "source": [
+    "# Football Results Analyser\n",
+    "\n",
+    "This notebook scrapes recent match results from **Flashscore.com** across multiple leagues using Selenium (required because the site is fully JavaScript-rendered \u2014 plain `requests` won't work), then feeds the data to an OpenAI model for a narrative analysis.\n",
+    "\n",
+    "**Leagues covered:** EPL \u00b7 La Liga \u00b7 Bundesliga\n",
+    "\n",
+    "**What it demonstrates:**\n",
+    "- Selenium for JS-heavy sites (addresses the limitation called out in `day1.ipynb`)\n",
+    "- Structuring scraped data as a pandas DataFrame before passing to an LLM\n",
+    "- Using a system prompt to steer the tone of analysis\n",
+    "- Displaying LLM output as rendered Markdown"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0002-0000-0000-000000000002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0003-0000-0000-000000000003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0004-0000-0000-000000000004",
+   "metadata": {},
+   "source": [
+    "## Step 1 \u2014 Scrape results\n",
+    "\n",
+    "The scraper runs a headless Chrome browser, dismisses the cookie banner, and waits for the match elements to load before extracting them. Set `headless=False` if you want to watch it work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0005-0000-0000-000000000005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scraper import scrape_all_leagues\n",
+    "\n",
+    "rows = scrape_all_leagues(headless=True)\n",
+    "df = pd.DataFrame(rows, columns=['league', 'date', 'home_team', 'score', 'away_team'])\n",
+    "print(f'Total matches scraped: {len(df)}')\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0006-0000-0000-000000000006",
+   "metadata": {},
+   "source": [
+    "## Step 2 \u2014 Results per league"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0007-0000-0000-000000000007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for league, group in df.groupby('league', sort=False):\n",
+    "    print(f'\\n=== {league} ({len(group)} matches) ===')\n",
+    "    print(group[['date', 'home_team', 'score', 'away_team']].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0008-0000-0000-000000000008",
+   "metadata": {},
+   "source": [
+    "## Step 3 \u2014 LLM Analysis\n",
+    "\n",
+    "We format the full results table as plain text and ask GPT to identify standout results, upsets, and scoring trends across all leagues."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0009-0000-0000-000000000009",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are an expert football analyst covering European football.\n",
+    "You will be given a batch of recent match results from multiple leagues.\n",
+    "Your job is to write a concise, insightful analysis that covers:\n",
+    "- The most surprising upsets or high-scoring games\n",
+    "- Any team that looks to be in outstanding or poor form\n",
+    "- A brief cross-league comparison of attacking play (goals per game)\n",
+    "Write in an engaging style. Respond in Markdown. Do not wrap the markdown in a code block.\n",
+    "\"\"\"\n",
+    "\n",
+    "def build_results_text(df):\n",
+    "    lines = []\n",
+    "    for league, group in df.groupby('league', sort=False):\n",
+    "        lines.append(f'### {league}')\n",
+    "        for _, row in group.iterrows():\n",
+    "            lines.append(f\"  {row['date']}  {row['home_team']} {row['score']} {row['away_team']}\")\n",
+    "        lines.append('')\n",
+    "    return '\\n'.join(lines)\n",
+    "\n",
+    "def analyse_results(df):\n",
+    "    results_text = build_results_text(df)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model='gpt-4.1-mini',\n",
+    "        messages=[\n",
+    "            {'role': 'system', 'content': system_prompt},\n",
+    "            {'role': 'user', 'content': f'Here are the latest results:\\n\\n{results_text}'}\n",
+    "        ]\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0010-0000-0000-000000000010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis = analyse_results(df)\n",
+    "display(Markdown(analysis))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0011-0000-0000-000000000011",
+   "metadata": {},
+   "source": [
+    "## Step 4 \u2014 Per-league breakdown\n",
+    "\n",
+    "Ask the model to focus on one league at a time for a deeper read."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0012-0000-0000-000000000012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def analyse_league(df, league_name):\n",
+    "    league_df = df[df['league'] == league_name]\n",
+    "    if league_df.empty:\n",
+    "        print(f'No data for {league_name}')\n",
+    "        return\n",
+    "    results_text = build_results_text(league_df)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model='gpt-4.1-mini',\n",
+    "        messages=[\n",
+    "            {'role': 'system', 'content': system_prompt},\n",
+    "            {'role': 'user', 'content': f'Focus only on {league_name}. Here are the results:\\n\\n{results_text}'}\n",
+    "        ]\n",
+    "    )\n",
+    "    display(Markdown(response.choices[0].message.content))\n",
+    "\n",
+    "analyse_league(df, 'EPL')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0013-0000-0000-000000000013",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analyse_league(df, 'La Liga')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-0014-0000-0000-000000000014",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analyse_league(df, 'Bundesliga')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0015-0000-0000-000000000015",
+   "metadata": {},
+   "source": [
+    "## Extending this notebook\n",
+    "\n",
+    "Some ideas to take this further:\n",
+    "\n",
+    "- **Add more leagues** \u2014 extend the `LEAGUES` dict in `scraper.py` with Serie A, Ligue 1, etc.\n",
+    "- **Predict upcoming fixtures** \u2014 scrape the fixtures page instead of results and ask GPT to predict outcomes\n",
+    "- **Track form over time** \u2014 run the scraper on a schedule and store results in a CSV to feed the model historical context\n",
+    "- **Export the analysis** \u2014 pipe the Markdown output into the PDF generator from the original project"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week1/community-contributions/gilbert-mutai/requirements.txt
+++ b/week1/community-contributions/gilbert-mutai/requirements.txt
@@ -1,0 +1,7 @@
+selenium>=4.0.0
+webdriver-manager>=4.0.0
+pandas>=2.0.0
+openpyxl>=3.1.0
+fpdf2>=2.7.0
+openai>=1.0.0
+python-dotenv>=1.0.0

--- a/week1/community-contributions/gilbert-mutai/scraper.py
+++ b/week1/community-contributions/gilbert-mutai/scraper.py
@@ -1,0 +1,76 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.service import Service as ChromeService
+from webdriver_manager.chrome import ChromeDriverManager
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import time
+
+LEAGUES = {
+    'EPL':        'https://www.flashscore.com/football/england/premier-league/results/',
+    'La Liga':    'https://www.flashscore.com/football/spain/laliga/results/',
+    'Bundesliga': 'https://www.flashscore.com/football/germany/bundesliga/results/',
+}
+
+
+def setup_driver(headless=True):
+    options = Options()
+    if headless:
+        options.add_argument('--headless=new')
+        options.add_argument('--no-sandbox')
+        options.add_argument('--disable-dev-shm-usage')
+    options.add_argument('--window-size=1920,1080')
+    driver = webdriver.Chrome(
+        service=ChromeService(ChromeDriverManager().install()),
+        options=options,
+    )
+    return driver
+
+
+def dismiss_cookie_banner(driver):
+    try:
+        WebDriverWait(driver, 5).until(
+            EC.element_to_be_clickable((By.ID, 'onetrust-accept-btn-handler'))
+        ).click()
+        time.sleep(0.5)
+    except Exception:
+        pass
+
+
+def scrape_league(driver, league_name, url):
+    print(f'Scraping {league_name} ...')
+    driver.get(url)
+
+    dismiss_cookie_banner(driver)
+
+    WebDriverWait(driver, 15).until(
+        EC.presence_of_all_elements_located((By.CSS_SELECTOR, '[class*="event__match"]'))
+    )
+
+    rows = []
+    matches = driver.find_elements(By.CSS_SELECTOR, '[class*="event__match"]')
+    for match in matches:
+        try:
+            date  = match.find_element(By.CSS_SELECTOR, '.event__time').text
+            home  = match.find_element(By.CSS_SELECTOR, '[class*="event__homeParticipant"] [class*="wcl-name"]').text
+            away  = match.find_element(By.CSS_SELECTOR, '[class*="event__awayParticipant"] [class*="wcl-name"]').text
+            goals = match.find_elements(By.CSS_SELECTOR, '[class*="event__score"]')
+            score = f'{goals[0].text} - {goals[1].text}' if len(goals) >= 2 else 'vs'
+            rows.append({'league': league_name, 'date': date, 'home_team': home, 'score': score, 'away_team': away})
+        except Exception:
+            continue
+
+    print(f'  → {len(rows)} matches found')
+    return rows
+
+
+def scrape_all_leagues(headless=True):
+    driver = setup_driver(headless=headless)
+    all_rows = []
+    try:
+        for league_name, url in LEAGUES.items():
+            all_rows.extend(scrape_league(driver, league_name, url))
+    finally:
+        driver.quit()
+    return all_rows

--- a/week1/community-contributions/gilbert-mutai/week1_day2_homework_ollama.ipynb
+++ b/week1/community-contributions/gilbert-mutai/week1_day2_homework_ollama.ipynb
@@ -1,0 +1,324 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0001-0000-0000-000000000001",
+   "metadata": {},
+   "source": [
+    "# Day 2 Homework — Web Summariser with Ollama\n",
+    "\n",
+    "This is the Day 1 web summariser rebuilt to use a **local open-source model via Ollama** instead of OpenAI.\n",
+    "\n",
+    "### What changes from Day 1\n",
+    "| Day 1 (OpenAI) | Day 2 (Ollama) |\n",
+    "|---|---|\n",
+    "| Requires `OPENAI_API_KEY` in `.env` | No API key needed |\n",
+    "| `OpenAI()` | `OpenAI(base_url='http://localhost:11434/v1', api_key='ollama')` |\n",
+    "| Model: `gpt-4.1-mini` | Model: `llama3.2` |\n",
+    "\n",
+    "Ollama exposes an OpenAI-compatible API locally, so the same Python client library works with just a different base URL.\n",
+    "Note: the variable is named `ollama` (not `openai`) to make clear we are talking to a local Ollama server, not OpenAI's cloud.\n",
+    "\n",
+    "### Prerequisites\n",
+    "1. Install Ollama from https://ollama.com\n",
+    "2. Pull the model: `ollama pull llama3.2`\n",
+    "3. Ollama runs automatically in the background once installed — no need to start it manually"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b1c2d3e4-0002-0000-0000-000000000002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0003-0000-0000-000000000003",
+   "metadata": {},
+   "source": [
+    "## Connect to Ollama\n",
+    "\n",
+    "No `.env` file or API key needed — Ollama runs locally on port 11434.\n",
+    "We use the OpenAI client library as a wrapper since Ollama exposes an OpenAI-compatible endpoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b1c2d3e4-0004-0000-0000-000000000004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ollama = OpenAI(base_url='http://localhost:11434/v1', api_key='ollama')\n",
+    "\n",
+    "MODEL = 'llama3.2'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0005-0000-0000-000000000005",
+   "metadata": {},
+   "source": [
+    "## Quick sanity check"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b1c2d3e4-0006-0000-0000-000000000006",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I'm happy to help you with any questions or information you need, and I'll do my best to provide a helpful response.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = ollama.chat.completions.create(\n",
+    "    model=MODEL,\n",
+    "    messages=[{'role': 'user', 'content': 'Hello! Reply in one sentence.'}]\n",
+    ")\n",
+    "print(response.choices[0].message.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0007-0000-0000-000000000007",
+   "metadata": {},
+   "source": [
+    "## Website scraper\n",
+    "\n",
+    "Same approach as Day 1 — `requests` + `BeautifulSoup` to strip out scripts, styles and navigation noise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b1c2d3e4-0008-0000-0000-000000000008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "HEADERS = {\n",
+    "    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'\n",
+    "}\n",
+    "\n",
+    "def fetch_website_contents(url):\n",
+    "    response = requests.get(url, headers=HEADERS)\n",
+    "    soup = BeautifulSoup(response.content, 'html.parser')\n",
+    "    title = soup.title.string if soup.title else 'No title found'\n",
+    "    if soup.body:\n",
+    "        for tag in soup.body(['script', 'style', 'img', 'input']):\n",
+    "            tag.decompose()\n",
+    "        text = soup.body.get_text(separator='\\n', strip=True)\n",
+    "    else:\n",
+    "        text = ''\n",
+    "    return (title + '\\n\\n' + text)[:5_000]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0009-0000-0000-000000000009",
+   "metadata": {},
+   "source": [
+    "## Prompts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b1c2d3e4-0010-0000-0000-000000000010",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are an assistant that analyzes the contents of a website and provides\n",
+    "a short summary, ignoring text that might be navigation related.\n",
+    "Respond in markdown. Do not wrap the markdown in a code block.\n",
+    "\"\"\"\n",
+    "\n",
+    "def messages_for(url):\n",
+    "    contents = fetch_website_contents(url)\n",
+    "    return [\n",
+    "        {'role': 'system', 'content': system_prompt},\n",
+    "        {'role': 'user', 'content': f'Here are the contents of a website. Provide a short summary.\\n\\n{contents}'}\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0011-0000-0000-000000000011",
+   "metadata": {},
+   "source": [
+    "## Summarise function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b1c2d3e4-0012-0000-0000-000000000012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def summarize(url):\n",
+    "    response = ollama.chat.completions.create(\n",
+    "        model=MODEL,\n",
+    "        messages=messages_for(url)\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "def display_summary(url):\n",
+    "    display(Markdown(summarize(url)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0013-0000-0000-000000000013",
+   "metadata": {},
+   "source": [
+    "## Try it out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b1c2d3e4-0014-0000-0000-000000000014",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Summary**\n",
+       "\n",
+       "The website is owned by Edward Donner, the co-founder and CTO of Nebula.io. He's a passionate AI enthusiast who shares his knowledge through courses on Udemy, which have gained massive success (specifically 500,000 enrolled across 194 countries). The website also features an \"Outsmart\" arena where language models battle each other in a diplomacy-themed game, as well as other AI-related content, such as posts and resources. Edward's personal story and his involvement with various AI projects are also covered on the site."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_summary('https://edwarddonner.com')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b1c2d3e4-0015-0000-0000-000000000015",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Summary**\n",
+       "\n",
+       "Recent news articles discuss various global topics. \n",
+       "\n",
+       "* A deal between the US and Iran to potentially end tensions is in progress, but details are not yet clear.\n",
+       "* Oil prices have decreased due to hopes of a peace agreement with Iran.\n",
+       "* Hong Kong astronaut Lee Yea-ek has launched into space as part of a Chinese mission, setting records for individual swimmers.\n",
+       "* A large-scale Russian attack on Ukraine resulted in the death of four people and many injuries.\n",
+       "* China's deadliest coal mining disaster in years occurred, leading to outrage among authorities and security concerns for the environment. \n",
+       "* Clashes broke out at Venezuelan prisons due to alleged mistreatment by authorities.\n",
+       "* Arsenal has finally won the Premier League title, marking a 22-year wait, while Indian billionaires have spent major amounts on foreign companies due to slowing domestic growth.\n",
+       "\n",
+       "Note that news articles are subject to change and may be updated or superseded over time."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_summary('https://bbc.com/news')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b1c2d3e4-0016-0000-0000-000000000016",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "# Anthropic Website Summary\n",
+       "Anthropic is a public benefit corporation working on securing the benefits and mitigating the risks of AI. The company focuses on building responsible AI solutions, prioritizing safety at the forefront.\n",
+       "\n",
+       "## Products and Services\n",
+       "- Claude: an AI platform designed for development and complex professional work.\n",
+       "- Myths: coming soon AI agent project.\n",
+       "- Claudia Code: enterprise code modernization solution.\n",
+       "- Claude Platform: customizable software development environment.\n",
+       "\n",
+       "## Research and Policy\n",
+       "Anthropic conducts research on Economic Futures, Alignment Science, and Transparency. They also publish the Responsible Scaling Policy and Claude's Constitution to guide their approach to secure AI benefits.\n",
+       "\n",
+       "## Community Engagement\n",
+       "The company engages in conversations and partnerships through forums like Claude 'Where everyone learns.'"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_summary('https://anthropic.com')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1c2d3e4-0017-0000-0000-000000000017",
+   "metadata": {},
+   "source": [
+    "## Try a different model\n",
+    "\n",
+    "Ollama supports many models. To try another one:\n",
+    "```bash\n",
+    "ollama pull mistral\n",
+    "ollama pull deepseek-r1\n",
+    "```\n",
+    "Then just change the `MODEL` variable above and re-run."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Scrapes EPL, La Liga, and Bundesliga results from Flashscore.com using headless Selenium (required for JS-rendered pages), then feeds the data to gpt-4.1-mini for cross-league analysis and per-league breakdowns.