### PR TITLE
🐛  Fixes a bug where Groq returns an empty response in the UI 

### DIFF
--- a/week4/day4.ipynb
+++ b/week4/day4.ipynb
@@ -262,7 +262,8 @@
    "source": [
     "def port(model, python):\n",
     "    client = clients[model]\n",
-    "    reasoning_effort = \"high\" if 'gpt' in model else None\n",
+    "    openai_reasoning_models = {\"gpt-5\"}\n",
+    "    reasoning_effort = \"high\" if model in openai_reasoning_models else None\n",
     "    response = client.chat.completions.create(model=model, messages=messages_for(python), reasoning_effort=reasoning_effort)\n",
     "    reply = response.choices[0].message.content\n",
     "    reply = reply.replace('```cpp','').replace('```','')\n",


### PR DESCRIPTION
Because Groq technically uses a model with "gpt" in the name but with no reasoning effort parameter, it shows an empty response in Gradio (although it still charges you and shows up in the billing dashboard on Groq) 

This fixes it by just defining the models that can have high reasoning effort, rather than using a fuzzy match for "gpt".

Hope this helps someone!