### PR TITLE
Adds an accessible technical tutor for screen reader and keyboard-only Users

### DIFF
--- a/week1/community-contributions/accessible-technical-concept-explainer.ipynb
+++ b/week1/community-contributions/accessible-technical-concept-explainer.ipynb
@@ -1,0 +1,346 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0942d445",
+   "metadata": {},
+   "source": [
+    "# Accessible Technical Concept Explainer\n",
+    "\n",
+    "A conversational tool that takes a technical question or concept and explains it in a way that is optimized for screen reader and keyboard-only users — people who cannot rely on diagrams, visual metaphors, or \"as you can see\" phrasing to understand technical ideas. \n",
+    "The tool is built twice: once using the Anthropic API for nuanced, context-aware explanations, and once using a local model, Llama 3.2, to demonstrate the same concept running entirely offline without an API key. \n",
+    "The explanation format is deliberately structured for linear audio consumption: a one-sentence plain language summary first, followed by an analogy that uses no visual references, followed by a step-by-step breakdown using numbered points that a screen reader announces clearly, followed by a concrete real-world example grounded in something a blind or low vision user would encounter in daily life, and ending with one follow-up question the user might want to ask next. \n",
+    "The tool avoids spatial metaphors (\"as shown above,\" \"the box on the left,\" \"the diagram below\"), color references used as the sole means of conveying information, and ASCII art or table-based layouts that become noise when read aloud."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "31959d56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fd93784c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Anthropic API Key exists and begins sk-ant-\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load environment variables\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')\n",
+    "\n",
+    "# Check the key\n",
+    "\n",
+    "if anthropic_api_key:\n",
+    "    print(f\"Anthropic API Key exists and begins {anthropic_api_key[:7]}\")\n",
+    "else:\n",
+    "    print(\"Anthropic API Key not set (and this is optional)\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2148dbfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect to OpenAI client library\n",
+    "# A thin wrapper around calls to HTTP endpoints\n",
+    "\n",
+    "anthropic_url = \"https://api.anthropic.com/v1/\"\n",
+    "ollama_url = \"http://localhost:11434/v1\"\n",
+    "\n",
+    "anthropic = OpenAI(api_key=anthropic_api_key, base_url=anthropic_url)\n",
+    "ollama = OpenAI(api_key=\"ollama\", base_url=ollama_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "df21aeff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are a technical educator specializing in explaining complex concepts \n",
+    "to blind and low vision learners who use screen readers and keyboard-only \n",
+    "navigation. Your explanations are optimized for audio consumption — \n",
+    "they will be read aloud by a screen reader, not read visually.\n",
+    "\n",
+    "Follow these rules on every response:\n",
+    "\n",
+    "STRUCTURE — always use this exact order:\n",
+    "1. One-sentence plain language summary of the concept\n",
+    "2. An analogy that uses no visual references — \n",
+    "   base it on sound, touch, movement, sequence, or \n",
+    "   everyday non-visual experience\n",
+    "3. Step-by-step breakdown — use numbered steps, \n",
+    "   each step one sentence, so the screen reader \n",
+    "   announces them as a clear sequence\n",
+    "4. A concrete example grounded in something a blind or \n",
+    "   low vision user encounters in daily life — \n",
+    "   VoiceOver navigation, Braille display output, \n",
+    "   keyboard shortcuts, accessible app behavior\n",
+    "5. One natural follow-up question the learner might want \n",
+    "   to explore next\n",
+    "\n",
+    "LANGUAGE RULES — never use:\n",
+    "- Visual spatial metaphors: \"as shown above\", \"the box on the left\", \n",
+    "  \"the diagram below\", \"as you can see\", \"looking at this\"\n",
+    "- Color as the sole means of conveying meaning: \n",
+    "  instead of \"the red items are errors\" say \n",
+    "  \"items marked as errors\"\n",
+    "- ASCII art, tables, or visual layouts that \n",
+    "  become noise when read aloud — use numbered \n",
+    "  or bulleted lists instead\n",
+    "- Parenthetical asides that interrupt screen reader flow — \n",
+    "  place all context in the main sentence\n",
+    "\n",
+    "TONE — practitioner to practitioner. \n",
+    "You are not simplifying for a beginner unless asked. \n",
+    "You are removing visual assumptions from a technical explanation, \n",
+    "not dumbing it down. The learner is technically capable — \n",
+    "they just need an explanation that works without a screen.\n",
+    "\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7f67b8ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_prompt_template = \"\"\"\n",
+    "Please explain the following technical concept in a way that is \n",
+    "fully accessible to a screen reader user. \n",
+    "Follow your structured explanation format.\n",
+    "\n",
+    "Concept or question: {user_question}\n",
+    "\n",
+    "If this concept is typically explained using a diagram, \n",
+    "flowchart, or visual metaphor, explicitly acknowledge that \n",
+    "and provide an alternative explanation grounded in \n",
+    "sequence, process, or analogy instead.\n",
+    "\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "58e0d73a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def explain_with_anthropic(question):\n",
+    "    \"\"\"Explain a technical concept using the Anthropic API.\"\"\"\n",
+    "    response = anthropic.chat.completions.create(\n",
+    "        model=\"claude-sonnet-4-6\",\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": system_prompt},\n",
+    "            {\"role\": \"user\", \"content\":\n",
+    "                user_prompt_template.format(user_question=question)}\n",
+    "        ]\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e3baf70a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def explain_with_ollama(question, model=\"llama3.2\"):\n",
+    "    \"\"\"\n",
+    "    Explain a technical concept using a local Ollama model.\n",
+    "    Runs entirely offline — no API key required.\n",
+    "    \"\"\"\n",
+    "    response = ollama.chat.completions.create(\n",
+    "        model=model,\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": system_prompt},\n",
+    "            {\"role\": \"user\", \"content\":\n",
+    "                user_prompt_template.format(user_question=question)}\n",
+    "        ]\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cf5ce52",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "IndentationError",
+     "evalue": "unexpected indent (2670115308.py, line 22)",
+     "output_type": "error",
+     "traceback": [
+      "  \u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 22\u001b[39m\n\u001b[31m    \u001b[39m\u001b[31mprint(ollama_response)\u001b[39m\n    ^\n\u001b[31mIndentationError\u001b[39m\u001b[31m:\u001b[39m unexpected indent\n"
+     ]
+    }
+   ],
+   "source": [
+    "def run_explainer():\n",
+    "    \"\"\"\n",
+    "    Main loop — runs both models on the same question\n",
+    "    so you can compare output quality.\n",
+    "    \"\"\"\n",
+    "    print(\"=== Accessible Technical Concept Explainer ===\")\n",
+    "    print(\"Explanations are structured for screen reader consumption.\")\n",
+    "    print(\"Type 'quit' to exit.\\n\")\n",
+    "\n",
+    "    question = input(\"Enter your technical question: \").strip()\n",
+    "\n",
+    "    print(\"\\n--- Anthropic (Claude) response ---\\n\")\n",
+    "    try:\n",
+    "        anthropic_response = explain_with_anthropic(question)\n",
+    "        print(anthropic_response)\n",
+    "    except Exception as e:\n",
+    "        print(f\"Anthropic call failed: {e}\")\n",
+    "\n",
+    "    print(\"\\n--- Ollama response (local, offline) ---\\n\")\n",
+    "    try:\n",
+    "        ollama_response = explain_with_ollama(question)\n",
+    "        print(ollama_response)\n",
+    "    except Exception as e:\n",
+    "        print(f\"Ollama call failed: {e}\")\n",
+    "\n",
+    "print(\"\\n\" + \"=\"*60 + \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "127dc8a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Accessible Technical Concept Explainer ===\n",
+      "Explanations are structured for screen reader consumption.\n",
+      "Type 'quit' to exit.\n",
+      "\n",
+      "\n",
+      "--- Anthropic (Claude) response ---\n",
+      "\n",
+      "## The Nullish Coalescing Operator in JavaScript\n",
+      "\n",
+      "**Plain language summary:** The double question mark operator, written as two consecutive question marks, lets you provide a fallback value that is used only when the left side is null or undefined, and nothing else.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "**Analogy:** Think of it like a Braille display that shows the content of a cell if any text is stored there, but switches to a default label if that cell is completely empty — not if the cell contains a zero, not if it contains a blank space, only if it contains absolutely nothing at all. Other fallback tools would trigger on a zero or a blank space, but this one is more precise.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "**Step-by-step breakdown:**\n",
+      "\n",
+      "1. JavaScript evaluates the expression on the left side of the operator.\n",
+      "2. If that left side evaluates to null or undefined, JavaScript uses the value on the right side instead.\n",
+      "3. If the left side evaluates to anything else, including zero, false, or an empty string, JavaScript keeps the left side value and ignores the right side entirely.\n",
+      "4. The result is that you get a reliable fallback without accidentally discarding legitimate values like zero or false.\n",
+      "5. You can chain multiple nullish coalescing operators in sequence, and JavaScript will walk through them left to right, stopping at the first value that is not null or undefined.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "**Concrete daily-life example:** Imagine you are writing a script for a screen reader settings panel. A user's preferred speech rate is stored in their profile, but new users have no value saved yet. You write:\n",
+      "\n",
+      "```javascript\n",
+      "const speechRate = userProfile.rate ?? 1.0;\n",
+      "```\n",
+      "\n",
+      "If the user has never set a rate, their stored value is undefined, so speechRate gets the fallback of 1.0. If the user deliberately set their rate to zero, which might mean silence for testing, the operator respects that zero and does not replace it with 1.0. Using the older logical OR operator instead would have treated zero as falsy and incorrectly overwritten it with 1.0, causing a hard-to-trace bug.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "**Follow-up question you might explore next:** How does the nullish coalescing operator interact with optional chaining, the question mark dot operator, when you need to safely access a deeply nested property before applying a fallback?\n",
+      "\n",
+      "--- Ollama response (local, offline) ---\n",
+      "\n",
+      "The ?? operator in JavaScript is a shorthand for the ternary operator and returns one value if the condition is true, or the other value if it's false.\n",
+      "\n",
+      "Imagine you're folding laundry with tactile labels. Each fold has a designated label such as \"top\" or \"bottom.\" When sorting clothes after washing, you need to identify which ones are clean (true) and which ones are dirty (false). You can use these labels to quickly pick up the right items without looking at each item.\n",
+      "\n",
+      "Step-by-step breakdown:\n",
+      "\n",
+      "1. The ?? operator is used in place of the ternary operator, which looks like this: condition ? value_if_true : value_if_false.\n",
+      "2. To use the ?? operator, start by placing it wherever you want the conditional logic to apply.\n",
+      "3. Inside the ?? operator, add your first \"value if true,\" separated from the \"?\" by a space.\n",
+      "4. Then, move forward two spaces and insert your second \"value if false.\"\n",
+      "5. End the expression with a null character (!).\n",
+      " \n",
+      "\n",
+      "Concrete example: When writing code in an IDE that supports ??, like Visual Studio for instance, you might use it to simplify conditional expressions like this:\n",
+      "\n",
+      "if (item.isClean) {\n",
+      "  result = item.label + '|clean';\n",
+      "} else {\n",
+      "  result = item.label + '|dirty';  \n",
+      "}\n",
+      " \n",
+      "In some cases, you could rewrite that as:\n",
+      " item.isClean ? item.label + '|clean' : item.label + '|dirty'\n",
+      "\n",
+      "This same example would also look like:\n",
+      "\n",
+      "let result = item.isClean ? item.label + '|clean' : item.label + '|dirty'\n",
+      "\n",
+      " A follow-up question for the learner might be: How does the ?? operator handle null or undefined values?\n",
+      "\n",
+      "============================================================\n",
+      "\n",
+      "Goodbye.\n"
+     ]
+    }
+   ],
+   "source": [
+    "run_explainer()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week1/community-contributions/accessible-technical-concept-explainer.ipynb
+++ b/week1/community-contributions/accessible-technical-concept-explainer.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "fd93784c",
    "metadata": {},
    "outputs": [
@@ -52,7 +52,7 @@
     "if anthropic_api_key:\n",
     "    print(f\"Anthropic API Key exists and begins {anthropic_api_key[:7]}\")\n",
     "else:\n",
-    "    print(\"Anthropic API Key not set (and this is optional)\")\n"
+    "    print(\"Anthropic API Key not set\")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
This PR adds an accessible technical concept explainer for screen reader and keyboard-only users.
The tool is built twice: once using the Anthropic API for nuanced, context-aware explanations, and once using a local model, Llama 3.2, to demonstrate the same concept running entirely offline without an API key. 
The explanation format is deliberately structured for linear audio consumption: a one-sentence plain language summary first, followed by an analogy that uses no visual references, followed by a step-by-step breakdown using numbered points that a screen reader announces clearly, followed by a concrete real-world example grounded in something a blind or low vision user would encounter in daily life, and ending with one follow-up question the user might want to ask next. 
The tool avoids spatial metaphors ("as shown above," "the box on the left," "the diagram below"), color references used as the sole means of conveying information, and ASCII art or table-based layouts that become noise when read aloud.
NOTE: I decided not to use a while loop to continuously take in question inputs because the accessibility of output from a running cell is not reliable. This behavior was found while testing with VSCode and the VoiceOver screen reader.

## Testing Done
The utility successfully calls Claude and Ollama to answer a technical question.