### PR TITLE
Add Snarky Landing Page & Messaging Auditor community contribution

### DIFF
--- a/week1/community-contributions/adeel/README.md
+++ b/week1/community-contributions/adeel/README.md
@@ -1,0 +1,15 @@
+# Snarky Landing Page & Messaging Auditor
+
+This project is a custom Week 1 contribution. It builds upon the basic webpage scraper by adding prompt chaining and a highly stylized system prompt to audit startup or company landing pages.
+
+## What it does
+1. **Scrapes the homepage** of any given URL, stripping navigation, scripts, and styling.
+2. **Translates corporate buzzwords** into plain English.
+3. **Rates the copy** based on a "Buzzword Bingo Score".
+4. **Performs a brutally honest SWOT Analysis** of their messaging and suggests improvements.
+
+## How to Run
+1. Ensure you have your `GOOGLE_API_KEY` set up in your `.env` file.
+2. Open `landing_page_auditor.ipynb` in Cursor.
+3. Select the `.venv` kernel.
+4. Run all cells and try entering your favorite startup or product URL!

--- a/week1/community-contributions/adeel/landing_page_auditor.ipynb
+++ b/week1/community-contributions/adeel/landing_page_auditor.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Snarky Landing Page & Messaging Auditor\n",
+    "An AI tool that scrapes a company's landing page, cuts through the corporate buzzwords, and gives a brutally honest audit of their messaging and value proposition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "load-env",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Google/Gemini API key loaded successfully!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load environment variables\n",
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv('GOOGLE_API_KEY')\n",
+    "\n",
+    "if not api_key:\n",
+    "    print(\"Warning: GOOGLE_API_KEY not found in environment. Please add it to your .env file.\")\n",
+    "else:\n",
+    "    print(\"Google/Gemini API key loaded successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "setup-client",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup client pointing to Gemini OpenAI-compatible endpoint\n",
+    "GEMINI_BASE_URL = \"https://generativelanguage.googleapis.com/v1beta/openai/\"\n",
+    "openai = OpenAI(base_url=GEMINI_BASE_URL, api_key=api_key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "scraper",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "headers = {\n",
+    "    \"User-Agent\": \"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36\"\n",
+    "}\n",
+    "\n",
+    "def fetch_landing_page(url):\n",
+    "    response = requests.get(url, headers=headers)\n",
+    "    soup = BeautifulSoup(response.content, 'html.parser')\n",
+    "    \n",
+    "    title = soup.title.string if soup.title else \"No title found\"\n",
+    "    \n",
+    "    # Strip unnecessary tags\n",
+    "    if soup.body:\n",
+    "        for irrelevant in soup.body([\"script\", \"style\", \"img\", \"input\", \"footer\", \"nav\"]):\n",
+    "            irrelevant.decompose()\n",
+    "        text = soup.body.get_text(separator=\"\\n\", strip=True)\n",
+    "    else:\n",
+    "        text = \"\"\n",
+    "        \n",
+    "    return title, text[:3000] # Limit to 3000 chars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "prompts",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are a cynical, experienced Venture Capitalist and branding critic.\n",
+    "You analyze landing page copy and provide a brutally honest, snarky, yet insightful messaging audit.\n",
+    "Your output must be in Markdown and follow these sections:\n",
+    "1. ## Plain English Translation\n",
+    "   Translate the marketing speak into 1-2 sentences explaining what this product actually does.\n",
+    "2. ## The Buzzword Bingo Score\n",
+    "   List the top 3-5 corporate buzzwords found (e.g. 'synergy', 'disruptive', 'seamlessly') and explain why they are meaningless in this context. Grade the copy from A (clean) to F (buzzword soup).\n",
+    "3. ## Brutally Honest SWOT\n",
+    "   Provide 1 bullet point for each: Strength, Weakness, Opportunity, Threat.\n",
+    "4. ## Suggested Fixes\n",
+    "   Give 2 snarky, practical suggestions on how they can improve their messaging.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "auditor",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def audit_landing_page(url):\n",
+    "    print(f\"Scraping and auditing: {url}...\\n\")\n",
+    "    title, text = fetch_landing_page(url)\n",
+    "    \n",
+    "    user_prompt = f\"Page Title: {title}\\n\\nPage Copy:\\n{text}\"\n",
+    "    \n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt}\n",
+    "    ]\n",
+    "    \n",
+    "    response = openai.chat.completions.create(\n",
+    "        model=\"gemini-2.5-flash\",\n",
+    "        messages=messages\n",
+    "    )\n",
+    "    \n",
+    "    display(Markdown(response.choices[0].message.content))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "run-audit",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scraping and auditing: https://openai.com...\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Alright, let's dissect this digital masterpiece. This isn't a landing page; it's a digital bouncer at the velvet rope, demanding technical compliance before I even know what the party is about. I've seen better user experiences trying to navigate the DMV.\n",
+       "\n",
+       "## Plain English Translation\n",
+       "\n",
+       "Your website, product, or whatever this is supposed to be, doesn't work unless the user jumps through technical hoops. In essence, it's a brick wall masquerading as a portal, designed to immediately frustrate anyone who isn't already tech-savvy or using a default browser setup.\n",
+       "\n",
+       "## The Buzzword Bingo Score\n",
+       "\n",
+       "There are no buzzwords. Not a single \"synergy,\" \"disruptive,\" or \"scalable solution\" in sight. This isn't a score of A for clean messaging; it's an F for failing to have *any* damn messaging beyond a technical error. It's like grading an empty exam sheet. The only 'word' that even implies a product is \"continue,\" which suggests there was something to begin with, but clearly, we're not seeing it.\n",
+       "\n",
+       "**Grade: F (for F-ailing to provide any meaningful content)**\n",
+       "\n",
+       "## Brutally Honest SWOT\n",
+       "\n",
+       "*   **Strength:** It's undeniably direct. There's no fluff, no marketing BS. You know precisely why you can't proceed. It's efficient at telling users to go elsewhere.\n",
+       "*   **Weakness:** This isn't a landing page; it's an error message that dumps the burden of resolution entirely on the user without offering any value or explanation. You're asking for effort before you've even piqued interest.\n",
+       "*   **Opportunity:** You could lean into the exclusivity. Brand it as \"The JavaScript-Enabled Elite Club.\" Only the technically compliant may proceed. It’s niche, but at least it's a strategy.\n",
+       "*   **Threat:** Your bounce rate will be effectively 100% for anyone who isn't already running the precise configuration you demand. You're actively repelling users before they even know what you're selling.\n",
+       "\n",
+       "## Suggested Fixes\n",
+       "\n",
+       "1.  **Get a Real Landing Page:** Seriously, create *any* content that describes what your product actually *does* and why I should care. Then, if you absolutely must, offer a polite, helpful explanation *below* the value proposition on how to \"enable JavaScript and cookies,\" perhaps with links to instructions, rather than just barking commands.\n",
+       "2.  **Pivot to \"Tech Support as a Service\":** If this is all you've got, stop pretending you're selling something else. Call your company \"JS & Cookie Enforcers Inc.\" and offer consulting services to other broken websites. At least then your messaging would align with your actual offering."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Try auditing a site!\n",
+    "audit_landing_page(\"https://openai.com\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae2a99d1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Summary
This PR adds a new community contribution project under `week1/community-contributions/adeel/`.

### What it does
The **Snarky Landing Page & Messaging Auditor** is a tool that scrapes startup/company landing pages, filters out navigation/script clutter, and uses an LLM (configured for Gemini/OpenAI API compatible endpoints) to audit the messaging.

It generates:
1. **Plain English Translation**: Cuts through corporate jargon to explain what the product actually does.
2. **Buzzword Bingo Score**: Critiques the use of meaningless corporate buzzwords and assigns a grade (A to F).
3. **Brutally Honest SWOT**: Messaging-focused SWOT points.
4. **Suggested Fixes**: Two snarky, practical copy suggestions.

### Checklist
- [x] All notebook outputs are cleared.
- [x] Only modifies files in the `community-contributions/adeel/` directory.
- [x] Lightweight implementation (one notebook and one README).
