### PR TITLE
Add Week 1 Day 2 Study Notes Generator

### DIFF
--- a/week1/community-contributions/amit-kumar-behera/day2_study_notes_generator.ipynb
+++ b/week1/community-contributions/amit-kumar-behera/day2_study_notes_generator.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4-0001-0001-0001-000000000001",
+   "metadata": {},
+   "source": [
+    "# Day 2 - Local Study Notes Generator\n",
+    "\n",
+    "Give it any URL and it will generate structured study notes using a local Ollama model — no API costs, data stays on your machine!\n",
+    "\n",
+    "**Output includes:**\n",
+    "- Summary of the topic\n",
+    "- Key Concepts\n",
+    "- Quiz Questions with Answers\n",
+    "\n",
+    "**Note:** Works best on static pages (Wikipedia, docs, blogs). For JavaScript-heavy sites, use a Selenium-based scraper.\n",
+    "\n",
+    "**Model:** `llama3.2` (switch to `llama3.2:1b` if your machine is slow)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a1b2c3d4-0001-0001-0001-000000000002",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Imports\n",
+    "\n",
+    "import os\n",
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a1b2c3d4-0001-0001-0001-000000000003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ollama client setup\n",
+    "\n",
+    "OLLAMA_BASE_URL = \"http://localhost:11434/v1\"\n",
+    "MODEL = \"llama3.2\"\n",
+    "\n",
+    "ollama = OpenAI(base_url=OLLAMA_BASE_URL, api_key='ollama')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a1b2c3d4-0001-0001-0001-000000000004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Website scraper — fetches and cleans webpage text\n",
+    "\n",
+    "def fetch_website_contents(url):\n",
+    "    headers = {\"User-Agent\": \"Mozilla/5.0 (compatible; StudyNotesBot/1.0)\"}\n",
+    "    response = requests.get(url, headers=headers)\n",
+    "    soup = BeautifulSoup(response.content, 'html.parser')\n",
+    "    if soup.body is None:\n",
+    "        raise ValueError(f\"Could not parse page body from {url}. Status: {response.status_code}\")\n",
+    "    for tag in soup.body.find_all([\"script\", \"style\", \"img\", \"input\"]):\n",
+    "        tag.decompose()\n",
+    "    return soup.body.get_text(separator=\"\\n\", strip=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a1b2c3d4-0001-0001-0001-000000000005",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# System prompt — tells the model what to generate\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "You are an expert educator and study notes generator.\n",
+    "Given the contents of a webpage, your job is to produce structured study notes in Markdown.\n",
+    "\n",
+    "Your notes must include:\n",
+    "1. **Summary** - A brief overview of the topic\n",
+    "2. **Key Concepts** - The most important ideas as bullet points\n",
+    "3. **Quiz Questions** - 3 to 5 questions to test understanding\n",
+    "4. **Answers** - After all questions, provide answers with a brief explanation for each\n",
+    "\n",
+    "Keep the language clear and beginner friendly.\n",
+    "Do not include navigation text, ads, or irrelevant content.\n",
+    "Respond only in Markdown.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a1b2c3d4-0001-0001-0001-000000000006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build messages list for the model\n",
+    "\n",
+    "MAX_CHARS = 6000  # keep well within llama3.2's context window\n",
+    "\n",
+    "def messages_for(text):\n",
+    "    truncated = text[:MAX_CHARS] + (\"\\n\\n[Content truncated for length]\" if len(text) > MAX_CHARS else \"\")\n",
+    "    return [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": (\n",
+    "            \"Here is the content of a webpage. \"\n",
+    "            \"Generate structured study notes with ALL sections: Summary, Key Concepts, Quiz Questions, and Answers.\\n\\n\"\n",
+    "            + truncated\n",
+    "        )}\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a1b2c3d4-0001-0001-0001-000000000007",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main function — ties everything together\n",
+    "\n",
+    "def generate_study_notes(url):\n",
+    "    text = fetch_website_contents(url)\n",
+    "    response = ollama.chat.completions.create(\n",
+    "        model=MODEL,\n",
+    "        messages=messages_for(text)\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a1b2c3d4-0001-0001-0001-000000000008",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display function — renders the notes as formatted Markdown\n",
+    "\n",
+    "def display_study_notes(url):\n",
+    "    notes = generate_study_notes(url)\n",
+    "    display(Markdown(notes))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a1b2c3d4-0001-0001-0001-000000000009",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Summary**\n",
+       "===\n",
+       "\n",
+       "Odisha, formerly known as Orissa, is a state located in eastern India. It is the eighth-largest state by area and the eleventh-largest by population with over 41 million inhabitants.\n",
+       "\n",
+       "**Key Concepts**\n",
+       "\n",
+       "*   Geography: Odisha has a coastline of 485 kilometers along the Bay of Bengal\n",
+       "*   Economy: The state's economy is driven by agriculture, particularly rice, wheat, and soybeans\n",
+       "*   Culture: Odisha is known for its rich cultural heritage, including its traditional dance forms such as OdISSi\\~\\-L~a~sh~na and folk music\n",
+       "*   Government: The state has a unicameral legislature and is governed by the Government of Odisha.\n",
+       "\n",
+       "**Quiz Questions**\n",
+       "\n",
+       "1.  What is the official language of Odisha?\n",
+       "    *   A) Hindi\n",
+       "    *   B) Odia\n",
+       "    *   C) English\n",
+       "2.  Which of the following is a major industry in Odisha?\n",
+       "    *   A) Textiles\n",
+       "    *   B) Agriculture\n",
+       "    *   C) Steel\n",
+       "3.  What is the capital city of Odisha?\n",
+       "    *   A) Bhubaneswar\n",
+       "    *   B) Cuttack\n",
+       "    *   C) Puri\n",
+       "\n",
+       "**Answers**\n",
+       "\n",
+       "1.  B) Odia\n",
+       "    *   Explanation: Odisha uses both the Odia language and English as official languages.\n",
+       "2.  B) Agriculture\n",
+       "    *   explanation: agriculture is a major component of Odisha&#x27;s economy with crop farming accounting for around 40% of the state production.\n",
+       "3.  A) Bhubaneswar\n",
+       "    *   Explanation: The capital was originally located in Cuttack but it had to be moved during political unrest and ultimately settled upon Bhubaneswar"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "display_study_notes(\"https://en.wikipedia.org/wiki/Odisha\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e903bded",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "033254e7",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# PR Title
Add Week 1 Day 2 - Local Study Notes Generator (Amit Kumar Behera)

---

## Summary

Adds a local study notes generator that scrapes any webpage and produces
structured study notes using a local Ollama model (llama3.2) — no API key
or cost required.

## Output

Given a URL, the notebook generates:
- **Summary** of the topic
- **Key Concepts** as bullet points
- **Quiz Questions** with answers and explanations

## How it works

1. Fetches and cleans webpage text using `requests` + `BeautifulSoup`
2. Sends the content to a local `llama3.2` model via the Ollama API
3. Renders structured Markdown notes in the notebook

## Notes

- Works best on static pages (Wikipedia, docs, blogs)
- For JS-heavy sites, pair with `day1_selenium.ipynb`
- Slow machine? Switch to `llama3.2:1b` in the config cell

## Tested on

- Wikipedia pages
- Model: `llama3.2` via Ollama running locally
