### PR TITLE
Community contribution: Nicholas Dean — week 1–8 exercises

### DIFF
--- a/community-contributions/NicholasDean/week1/week1_exercise.ipynb
+++ b/community-contributions/NicholasDean/week1/week1_exercise.ipynb
@@ -1,0 +1,318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "36d9aa89",
+   "metadata": {},
+   "source": [
+    "# Week 1 exercise — Technical question explainer\n",
+    "\n",
+    "Ask any technical question and get a streamed explanation from a **frontier** model\n",
+    "(`gpt-4o-mini`) and a **local** model (`llama3.2` via Ollama). One function drives both,\n",
+    "because Ollama exposes an OpenAI-compatible API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b06d92a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:38:42.239093Z",
+     "iopub.status.busy": "2026-06-22T18:38:42.238594Z",
+     "iopub.status.idle": "2026-06-22T18:38:43.014447Z",
+     "shell.execute_reply": "2026-06-22T18:38:43.013439Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display, update_display\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "MODEL_GPT = \"gpt-4o-mini\"\n",
+    "MODEL_LLAMA = \"llama3.2\"\n",
+    "\n",
+    "frontier = OpenAI()  # uses OPENAI_API_KEY\n",
+    "local = OpenAI(base_url=\"http://localhost:11434/v1\", api_key=\"ollama\")  # Ollama, OpenAI-compatible\n",
+    "\n",
+    "SYSTEM = \"You are a helpful technical tutor. Explain clearly and concisely, with a short example when useful. Use markdown.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6eaaeb4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:38:43.016444Z",
+     "iopub.status.busy": "2026-06-22T18:38:43.015945Z",
+     "iopub.status.idle": "2026-06-22T18:38:43.020016Z",
+     "shell.execute_reply": "2026-06-22T18:38:43.019509Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def explain(question, client, model):\n",
+    "    \"\"\"Stream an explanation and render it live as markdown.\"\"\"\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": SYSTEM},\n",
+    "        {\"role\": \"user\", \"content\": question},\n",
+    "    ]\n",
+    "    stream = client.chat.completions.create(model=model, messages=messages, stream=True)\n",
+    "    reply = \"\"\n",
+    "    handle = display(Markdown(\"\"), display_id=True)\n",
+    "    for chunk in stream:\n",
+    "        reply += chunk.choices[0].delta.content or \"\"\n",
+    "        update_display(Markdown(reply), display_id=handle.display_id)\n",
+    "    return reply"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "44cfaf62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:38:43.021513Z",
+     "iopub.status.busy": "2026-06-22T18:38:43.021513Z",
+     "iopub.status.idle": "2026-06-22T18:38:43.027841Z",
+     "shell.execute_reply": "2026-06-22T18:38:43.027334Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Type over this to ask anything\n",
+    "question = \"\"\"\n",
+    "Please explain what this code does and why:\n",
+    "yield from {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17878db6",
+   "metadata": {},
+   "source": [
+    "### Frontier model — gpt-4o-mini"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2370248a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:38:43.029842Z",
+     "iopub.status.busy": "2026-06-22T18:38:43.029342Z",
+     "iopub.status.idle": "2026-06-22T18:38:51.689216Z",
+     "shell.execute_reply": "2026-06-22T18:38:51.688711Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "The code you've provided is a Python expression that uses a combination of a generator, a set comprehension, and the `yield from` statement. Here’s a breakdown of what each part does:\n",
+       "\n",
+       "### Breakdown of the Code\n",
+       "\n",
+       "1. **Set Comprehension**:\n",
+       "   ```python\n",
+       "   {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+       "   ```\n",
+       "   This part creates a set of authors from a collection of `books`. Here's how it works:\n",
+       "   - `for book in books`: Iterates over each `book` in the `books` list.\n",
+       "   - `book.get(\"author\")`: Retrieves the value associated with the key \"author\" from the `book` dictionary.\n",
+       "   - `if book.get(\"author\")`: This condition checks if the \"author\" exists and is truthy (i.e., not `None`, empty string, etc.). If it is, the author is included in the set.\n",
+       "   - The entire expression returns a set of unique authors because sets automatically handle duplicate values.\n",
+       "\n",
+       "2. **Yield from**:\n",
+       "   ```python\n",
+       "   yield from ...\n",
+       "   ```\n",
+       "   The `yield from` statement is used to yield all values from a generator or iterable. In this context, it is applied to the set comprehension created earlier, effectively allowing you to yield each unique author one at a time.\n",
+       "\n",
+       "### Purpose of the Code\n",
+       "\n",
+       "This code snippet would typically be part of a generator function, and its purpose is to return each unique author from the list of books one at a time. Since it uses `yield from`, it allows for efficient handling of the authors without the need to store them in a separate list or array.\n",
+       "\n",
+       "### Example\n",
+       "\n",
+       "Here’s a simple example demonstrating how this code might be used:\n",
+       "\n",
+       "```python\n",
+       "def get_unique_authors(books):\n",
+       "    yield from {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+       "\n",
+       "# Sample data\n",
+       "books = [\n",
+       "    {\"title\": \"Book 1\", \"author\": \"Author A\"},\n",
+       "    {\"title\": \"Book 2\", \"author\": \"Author B\"},\n",
+       "    {\"title\": \"Book 3\", \"author\": \"Author A\"},  # Duplicate author\n",
+       "    {\"title\": \"Book 4\"}  # No author\n",
+       "]\n",
+       "\n",
+       "# Using the generator\n",
+       "for author in get_unique_authors(books):\n",
+       "    print(author)\n",
+       "```\n",
+       "\n",
+       "### Output\n",
+       "```\n",
+       "Author A\n",
+       "Author B\n",
+       "```\n",
+       "\n",
+       "In this example, the generator function `get_unique_authors` yields unique authors from the `books` list, demonstrating the use of `yield from` with a set comprehension effectively."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_ = explain(question, frontier, MODEL_GPT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b74ba014",
+   "metadata": {},
+   "source": [
+    "### Local model — llama3.2 (Ollama)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "12781527",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:38:51.690716Z",
+     "iopub.status.busy": "2026-06-22T18:38:51.690716Z",
+     "iopub.status.idle": "2026-06-22T18:38:59.515666Z",
+     "shell.execute_reply": "2026-06-22T18:38:59.515158Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "**Generator Expression**\n",
+       "==========================\n",
+       "\n",
+       "The given code uses a combination of two concepts: generator expression and `yield from`.\n",
+       "\n",
+       "### Generator Expression\n",
+       "\n",
+       "A generator expression is a compact way to create a generator, which is an iterable object that can be used to generate a sequence of values, one at a time.\n",
+       "\n",
+       "Example:\n",
+       "```python\n",
+       "numbers = (x**2 for x in range(3))  # generator expression\n",
+       "print(next(numbers))  # prints 0\n",
+       "print(next(numbers))  # prints 1\n",
+       "print(next(numbers))  # prints 4\n",
+       "```\n",
+       "\n",
+       "In this example, the generator expression creates a sequence of squares of numbers from `range(3)`.\n",
+       "\n",
+       "### Yield from\n",
+       "\n",
+       "`yield from` is a keyword used to pause the execution of a generator and delegate control to another generator. It allows you to yield values from another generator without having to implement a loop in Python code.\n",
+       "\n",
+       "Example:\n",
+       "```python\n",
+       "def inner_generator():\n",
+       "    print(\"Inner gen\")\n",
+       "\n",
+       "    def small_gen():\n",
+       "        for i in [1, 2]:\n",
+       "            print(i)\n",
+       "    yield from small_gen()\n",
+       "\n",
+       "inner_generator()\n",
+       "```\n",
+       "\n",
+       "Output:\n",
+       "```\n",
+       "Inner gen\n",
+       "1\n",
+       "2\n",
+       "```\n",
+       "\n",
+       "In this example, the `inner_generator` yields values from a nested generator called `small_gen`.\n",
+       "\n",
+       "### Code Explanation\n",
+       "\n",
+       "Now, let's apply these concepts to the original code:\n",
+       "\n",
+       "```python\n",
+       "yield from {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+       "```\n",
+       "\n",
+       "This code uses a combination of `dict.get()` and a generator expression wrapped inside `{...}`. The dictionary values are obtained using `.get(\"author\")`, and the result is an iterator.\n",
+       "\n",
+       "The generator expression `(book.get(\"author\")) for book in books if book.get(\"author\")` yields values (i.e., authors) from each item `book` in the list `books`. However, due to a potential AttributeError when searching the dictionary value which may not exist, Python catches the error and uses `None` instead.\n",
+       "\n",
+       "So, this code snippet essentially extracts all the author names from the `books` list while handling cases where authors might be missing.\n",
+       "\n",
+       "Example Code with `List of Books**\n",
+       "```python\n",
+       "import json\n",
+       "\n",
+       "class Book:\n",
+       "    def __init__(self, **kwargs):\n",
+       "        self.__dict__.update(kwargs)\n",
+       "\n",
+       "books = [\n",
+       "    {\"title\": \"Pride and Prejudice\", \"author\":\"Jane Austen\"},\n",
+       "    {\"title\": \"Wuthering Heights\",},  # intentionally missing author field\n",
+       "    {\"title\": \"Frankenstein\", \"author\": \"Mary Shelley\"}\n",
+       "]\n",
+       "\n",
+       "author_names = yield from {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+       "print(author_names) # prints [None, None, 'Mary Shelley']\n",
+       "```"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_ = explain(question, local, MODEL_LLAMA)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week2/week2_exercise.ipynb
+++ b/community-contributions/NicholasDean/week2/week2_exercise.ipynb
@@ -1,0 +1,203 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4685dd50",
+   "metadata": {},
+   "source": [
+    "# Week 2 exercise — Technical tutor (Gradio prototype)\n",
+    "\n",
+    "The week-1 tech Q&A tool, now a full prototype: **Gradio chat UI**, **streaming**, a\n",
+    "**system prompt** for expertise, and a dropdown to **switch models** across providers\n",
+    "(`gpt-4o-mini`, `claude-haiku-4.5`, local `llama3.2`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1ebafe28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:29:04.403210Z",
+     "iopub.status.busy": "2026-06-22T18:29:04.403210Z",
+     "iopub.status.idle": "2026-06-22T18:29:07.584245Z",
+     "shell.execute_reply": "2026-06-22T18:29:07.583740Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import gradio as gr\n",
+    "import anthropic\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "frontier = OpenAI()\n",
+    "claude = anthropic.Anthropic()\n",
+    "local = OpenAI(base_url=\"http://localhost:11434/v1\", api_key=\"ollama\")\n",
+    "\n",
+    "# label -> (provider, model id)\n",
+    "MODELS = {\n",
+    "    \"gpt-4o-mini\": (\"openai\", \"gpt-4o-mini\"),\n",
+    "    \"claude-haiku-4.5\": (\"anthropic\", \"claude-haiku-4-5-20251001\"),\n",
+    "    \"llama3.2\": (\"ollama\", \"llama3.2\"),\n",
+    "}\n",
+    "\n",
+    "SYSTEM = \"You are an expert technical tutor. Explain clearly and concisely, with a short example when useful. Use markdown.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1b86ad6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:29:07.587244Z",
+     "iopub.status.busy": "2026-06-22T18:29:07.586245Z",
+     "iopub.status.idle": "2026-06-22T18:29:07.592026Z",
+     "shell.execute_reply": "2026-06-22T18:29:07.591521Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def chat(message, history, model_label):\n",
+    "    \"\"\"Stream a reply. `history` is Gradio's list of {role, content} messages.\"\"\"\n",
+    "    provider, model = MODELS[model_label]\n",
+    "    if provider == \"anthropic\":\n",
+    "        with claude.messages.stream(\n",
+    "            model=model, system=SYSTEM, max_tokens=1000,\n",
+    "            messages=history + [{\"role\": \"user\", \"content\": message}],\n",
+    "        ) as stream:\n",
+    "            reply = \"\"\n",
+    "            for text in stream.text_stream:\n",
+    "                reply += text\n",
+    "                yield reply\n",
+    "    else:\n",
+    "        client = frontier if provider == \"openai\" else local\n",
+    "        messages = [{\"role\": \"system\", \"content\": SYSTEM}] + history + [{\"role\": \"user\", \"content\": message}]\n",
+    "        stream = client.chat.completions.create(model=model, messages=messages, stream=True)\n",
+    "        reply = \"\"\n",
+    "        for chunk in stream:\n",
+    "            reply += chunk.choices[0].delta.content or \"\"\n",
+    "            yield reply"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "261c61e0",
+   "metadata": {},
+   "source": [
+    "Quick check that each model streams (prints the final reply):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "782e8a63",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T18:29:07.594026Z",
+     "iopub.status.busy": "2026-06-22T18:29:07.593528Z",
+     "iopub.status.idle": "2026-06-22T18:29:13.918900Z",
+     "shell.execute_reply": "2026-06-22T18:29:13.918394Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[gpt-4o-mini] A Python decorator is a design pattern that allows you to modify the behavior of a function or method by wrapping it in another function, typically used to add functionality, like logging or access control, without altering the original function's code.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[claude-haiku-4.5] A decorator is a function that modifies or wraps another function or class to change its behavior without permanently altering its source code.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[llama3.2] A Python decorator is a small function that takes another function as an argument and returns a new function that \"wraps\" the original function, allowing for the addition of additional functionality or behavior to be applied before or after the execution of the original function.\n",
+      "\n",
+      "**Example:**\n",
+      "```python\n",
+      "def my_decorator(func):\n",
+      "    def wrapper():\n",
+      "        print(\"Before executing the function\")\n",
+      "        func()\n",
+      "        print(\"After executing the function\")\n",
+      "    return wrapper\n",
+      "\n",
+      "@my_decorator\n",
+      "def say_hello():\n",
+      "    print(\"Hello!\")\n",
+      "\n",
+      "say_hello()  # Output: Before executing the function, Hello!, After executing the function\n",
+      "```\n",
+      "In this example, `my_decorator` is a decorator that prints a message before and after the execution of the `say_hello()` function. The `@my_decorator` syntax before the function definition allows for easy application of the decorator to existing code.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for label in MODELS:\n",
+    "    reply = \"\"\n",
+    "    for reply in chat(\"In one sentence, what is a Python decorator?\", [], label):\n",
+    "        pass\n",
+    "    print(f\"[{label}] {reply}\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c82d91da",
+   "metadata": {},
+   "source": [
+    "Launch the UI:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c02b75bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "demo = gr.ChatInterface(\n",
+    "    fn=chat,\n",
+    "    type=\"messages\",\n",
+    "    title=\"Technical tutor\",\n",
+    "    additional_inputs=[gr.Dropdown(list(MODELS), value=\"gpt-4o-mini\", label=\"Model\")],\n",
+    ")\n",
+    "demo.launch()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week3/week3_exercise.ipynb
+++ b/community-contributions/NicholasDean/week3/week3_exercise.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2ac5943b",
+   "metadata": {},
+   "source": [
+    "# Week 3 exercise — open-source models, locally\n",
+    "\n",
+    "Week 3 is about Hugging Face: **tokenizers**, **pipelines**, and running **open-source\n",
+    "models**. The Day-5 meeting-minutes project uses Whisper + Llama-8B on a Colab GPU; here\n",
+    "is a minimal version that runs **locally on CPU** — compare tokenizers, then turn a\n",
+    "meeting transcript into minutes with an open-source summarizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e6ae8f89",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T20:54:03.205501Z",
+     "iopub.status.busy": "2026-06-22T20:54:03.205501Z",
+     "iopub.status.idle": "2026-06-22T20:54:09.572859Z",
+     "shell.execute_reply": "2026-06-22T20:54:09.572354Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer, pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0403865b",
+   "metadata": {},
+   "source": [
+    "## 1. Tokenizers\n",
+    "Different models split the same text differently. Tokenizers are tiny (no model weights),\n",
+    "so this runs instantly. (Uses ungated models — no Hugging Face login needed.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b47cbed0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T20:54:09.574872Z",
+     "iopub.status.busy": "2026-06-22T20:54:09.574365Z",
+     "iopub.status.idle": "2026-06-22T20:54:10.687397Z",
+     "shell.execute_reply": "2026-06-22T20:54:10.686890Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gpt2                          11 tokens  ->  ['Token', 'ization', 'Ġturns', 'Ġtext', 'Ġinto', 'Ġintegers', 'Ġa', 'Ġmodel'] ...\n",
+      "bert-base-uncased             13 tokens  ->  ['[CLS]', 'token', '##ization', 'turns', 'text', 'into', 'integers', 'a'] ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Qwen/Qwen2.5-0.5B-Instruct    11 tokens  ->  ['Token', 'ization', 'Ġturns', 'Ġtext', 'Ġinto', 'Ġintegers', 'Ġa', 'Ġmodel'] ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "text = \"Tokenization turns text into integers a model can process.\"\n",
+    "for name in [\"gpt2\", \"bert-base-uncased\", \"Qwen/Qwen2.5-0.5B-Instruct\"]:\n",
+    "    tok = AutoTokenizer.from_pretrained(name)\n",
+    "    ids = tok.encode(text)\n",
+    "    print(f\"{name:<28} {len(ids):>3} tokens  ->  {tok.convert_ids_to_tokens(ids)[:8]} ...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70036ad1",
+   "metadata": {},
+   "source": [
+    "## 2. Meeting minutes from an open-source model\n",
+    "A local summarization pipeline (open weights, CPU) condenses a transcript into minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d62410a4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-22T20:54:10.688394Z",
+     "iopub.status.busy": "2026-06-22T20:54:10.688394Z",
+     "iopub.status.idle": "2026-06-22T20:54:12.477074Z",
+     "shell.execute_reply": "2026-06-22T20:54:12.476570Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Device set to use cpu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Both `max_new_tokens` (=256) and `max_length`(=80) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MEETING MINUTES\n",
+      "--------------\n",
+      "Alex: Great. Let's ship to the app stores Thursday so Friday's email points to a live app . Sam: Marketing is ready. We'll send the announcement email on Friday morning .\n"
+     ]
+    }
+   ],
+   "source": [
+    "transcript = \"\"\"\n",
+    "Alex: Welcome everyone. The goal today is to lock the launch plan for the mobile app.\n",
+    "Maria: Beta testing is done. We found two minor bugs, both fixed and verified yesterday.\n",
+    "Sam: Marketing is ready. We'll send the announcement email on Friday morning.\n",
+    "Alex: Great. Let's ship to the app stores Thursday so Friday's email points to a live app.\n",
+    "Maria: I'll submit the build Thursday and monitor the review queue.\n",
+    "Sam: I'll prepare the social posts and schedule them for Friday.\n",
+    "Alex: Perfect. We meet again Monday to review launch metrics.\n",
+    "\"\"\"\n",
+    "\n",
+    "summarizer = pipeline(\"summarization\", model=\"Falconsai/text_summarization\")\n",
+    "minutes = summarizer(transcript, max_length=80, min_length=25, do_sample=False)[0][\"summary_text\"]\n",
+    "print(\"MEETING MINUTES\\n\" + \"-\" * 14 + \"\\n\" + minutes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec880b4a",
+   "metadata": {},
+   "source": [
+    "**Full version (Colab GPU):** transcribe real audio with `openai/whisper`, then generate\n",
+    "structured minutes with a quantized `meta-llama/Llama-3.1-8B-Instruct` — see Day 5."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week4/week4_exercise.ipynb
+++ b/community-contributions/NicholasDean/week4/week4_exercise.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ded8f625",
+   "metadata": {},
+   "source": [
+    "# Week 4 exercise — code generator (Python -> C++)\n",
+    "\n",
+    "Use frontier models to rewrite slow Python as high-performance C++, then **compile and\n",
+    "benchmark** to prove the speed-up. Two models generate the C++ (`gpt-4o-mini` vs\n",
+    "`claude-haiku-4.5`) so we can compare them — the week-4 theme of *picking the right model*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "743502cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:12:44.881183Z",
+     "iopub.status.busy": "2026-06-23T12:12:44.880682Z",
+     "iopub.status.idle": "2026-06-23T12:12:46.312440Z",
+     "shell.execute_reply": "2026-06-23T12:12:46.311932Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "g++: C:\\ProgramData\\mingw64\\mingw64\\bin\\g++.exe\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, shutil, subprocess, time\n",
+    "import anthropic\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "frontier = OpenAI()\n",
+    "claude = anthropic.Anthropic()\n",
+    "\n",
+    "# g++ from PATH; fallback to the choco-installed MinGW (space-free path)\n",
+    "GPP = shutil.which(\"g++\") or r\"C:\\ProgramData\\mingw64\\mingw64\\bin\\g++.exe\"\n",
+    "BUILD = r\"C:\\Users\\Public\\llm_week4_build\"\n",
+    "os.makedirs(BUILD, exist_ok=True)\n",
+    "print(\"g++:\", GPP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ed18ec5a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:12:46.314437Z",
+     "iopub.status.busy": "2026-06-23T12:12:46.314437Z",
+     "iopub.status.idle": "2026-06-23T12:12:46.318036Z",
+     "shell.execute_reply": "2026-06-23T12:12:46.317531Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The slow Python we want to accelerate (integer-only so C++ output matches exactly)\n",
+    "PYTHON = '''\n",
+    "def count_primes(n):\n",
+    "    count = 0\n",
+    "    for x in range(2, n):\n",
+    "        d, prime = 2, True\n",
+    "        while d * d <= x:\n",
+    "            if x % d == 0:\n",
+    "                prime = False\n",
+    "                break\n",
+    "            d += 1\n",
+    "        if prime:\n",
+    "            count += 1\n",
+    "    return count\n",
+    "\n",
+    "print(count_primes(300000))\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "53cbc310",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:12:46.320038Z",
+     "iopub.status.busy": "2026-06-23T12:12:46.320038Z",
+     "iopub.status.idle": "2026-06-23T12:12:46.325632Z",
+     "shell.execute_reply": "2026-06-23T12:12:46.325124Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "SYSTEM = (\n",
+    "    \"Rewrite the given Python as a single high-performance C++17 program. \"\n",
+    "    \"Reply with ONLY C++ source code - no markdown, no commentary. Include all headers \"\n",
+    "    \"and an int main() that prints exactly the same output as the Python.\"\n",
+    ")\n",
+    "\n",
+    "def clean(text):\n",
+    "    return \"\\n\".join(l for l in text.splitlines() if not l.strip().startswith(\"```\")).strip()\n",
+    "\n",
+    "def to_cpp(provider, model):\n",
+    "    if provider == \"anthropic\":\n",
+    "        msg = claude.messages.create(model=model, system=SYSTEM, max_tokens=1500,\n",
+    "                                     messages=[{\"role\": \"user\", \"content\": PYTHON}])\n",
+    "        return clean(msg.content[0].text)\n",
+    "    r = frontier.chat.completions.create(model=model, messages=[\n",
+    "        {\"role\": \"system\", \"content\": SYSTEM}, {\"role\": \"user\", \"content\": PYTHON}])\n",
+    "    return clean(r.choices[0].message.content)\n",
+    "\n",
+    "def compile_and_run(cpp, name):\n",
+    "    src, exe = os.path.join(BUILD, name + \".cpp\"), os.path.join(BUILD, name + \".exe\")\n",
+    "    with open(src, \"w\") as f:\n",
+    "        f.write(cpp)\n",
+    "    subprocess.run([GPP, \"-O3\", \"-std=c++17\", \"-o\", exe, src], check=True, capture_output=True, text=True)\n",
+    "    t = time.time()\n",
+    "    out = subprocess.run([exe], capture_output=True, text=True).stdout.strip()\n",
+    "    return out, time.time() - t"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c77d2da4",
+   "metadata": {},
+   "source": [
+    "### Baseline: run the Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0cffd452",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:12:46.327631Z",
+     "iopub.status.busy": "2026-06-23T12:12:46.327130Z",
+     "iopub.status.idle": "2026-06-23T12:12:47.327523Z",
+     "shell.execute_reply": "2026-06-23T12:12:47.326516Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "25997\n",
+      "python: 0.996s\n"
+     ]
+    }
+   ],
+   "source": [
+    "ns = {}\n",
+    "t = time.time(); exec(PYTHON, ns); py_time = time.time() - t\n",
+    "print(f\"python: {py_time:.3f}s\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b25ffac",
+   "metadata": {},
+   "source": [
+    "### Generate C++ with each model, compile, run, compare"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b53a6cff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:12:47.329022Z",
+     "iopub.status.busy": "2026-06-23T12:12:47.329022Z",
+     "iopub.status.idle": "2026-06-23T12:12:55.229392Z",
+     "shell.execute_reply": "2026-06-23T12:12:55.228887Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gpt-4o-mini        output=25997    time=0.0710s  speedup x14\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "claude-haiku-4.5   output=25997    time=0.0715s  speedup x14\n"
+     ]
+    }
+   ],
+   "source": [
+    "for label, provider, model in [\n",
+    "    (\"gpt-4o-mini\", \"openai\", \"gpt-4o-mini\"),\n",
+    "    (\"claude-haiku-4.5\", \"anthropic\", \"claude-haiku-4-5-20251001\"),\n",
+    "]:\n",
+    "    cpp = to_cpp(provider, model)\n",
+    "    out, cpp_time = compile_and_run(cpp, label.replace(\".\", \"\"))\n",
+    "    speedup = py_time / cpp_time if cpp_time else float(\"inf\")\n",
+    "    print(f\"{label:<18} output={out:<8} time={cpp_time:.4f}s  speedup x{speedup:,.0f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week5/week5_exercise.ipynb
+++ b/community-contributions/NicholasDean/week5/week5_exercise.ipynb
@@ -1,0 +1,173 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8330593f",
+   "metadata": {},
+   "source": [
+    "# Week 5 exercise — RAG over the knowledge base\n",
+    "\n",
+    "**RAG** = Retrieval-Augmented Generation: instead of stuffing everything into the prompt,\n",
+    "store documents as vectors, **retrieve** only the few relevant ones for a question, and feed\n",
+    "those to the model. Here: index the Insurellm knowledge base in a Chroma vector DB (local\n",
+    "embeddings), then answer questions grounded in the retrieved docs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dbf61959",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:35:28.769313Z",
+     "iopub.status.busy": "2026-06-23T12:35:28.769313Z",
+     "iopub.status.idle": "2026-06-23T12:35:30.228635Z",
+     "shell.execute_reply": "2026-06-23T12:35:30.228126Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "knowledge base: C:\\Users\\Nicholas Dean\\projects\\llm_engineering\\week5\\knowledge-base\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "import chromadb\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "frontier = OpenAI()\n",
+    "\n",
+    "# find the course knowledge base by walking up from the working dir (robust to where this runs)\n",
+    "KB = next(p / \"week5/knowledge-base\" for p in [Path.cwd(), *Path.cwd().parents]\n",
+    "          if (p / \"week5/knowledge-base\").exists())\n",
+    "print(\"knowledge base:\", KB)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "263a4e4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:35:30.230632Z",
+     "iopub.status.busy": "2026-06-23T12:35:30.230135Z",
+     "iopub.status.idle": "2026-06-23T12:35:32.890889Z",
+     "shell.execute_reply": "2026-06-23T12:35:32.890385Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "indexed 76 documents\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load every doc and index it. Chroma's default embedder runs locally (MiniLM, no API cost).\n",
+    "docs, ids, metas = [], [], []\n",
+    "for f in sorted(KB.rglob(\"*.md\")):\n",
+    "    docs.append(f.read_text(encoding=\"utf-8\"))           # the document text\n",
+    "    ids.append(str(f.relative_to(KB)))                   # a unique id (its relative path)\n",
+    "    metas.append({\"category\": f.parent.name})            # company / products / employees / contracts\n",
+    "\n",
+    "collection = chromadb.Client().create_collection(\"insurellm\")\n",
+    "collection.add(documents=docs, ids=ids, metadatas=metas)  # embeds + stores all docs\n",
+    "print(f\"indexed {collection.count()} documents\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0c35e6d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T12:35:32.892892Z",
+     "iopub.status.busy": "2026-06-23T12:35:32.892391Z",
+     "iopub.status.idle": "2026-06-23T12:35:37.314021Z",
+     "shell.execute_reply": "2026-06-23T12:35:37.313512Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q: Who is the CEO of Insurellm?\n",
+      "A: The CEO of Insurellm is Avery Lancaster.\n",
+      "   sources: ['company\\\\about.md', 'company\\\\overview.md', 'employees\\\\Avery Lancaster.md', 'company\\\\careers.md']\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Q: What products does Insurellm offer?\n",
+      "A: Insurellm offers 8 insurance software products across multiple insurance lines:\n",
+      "\n",
+      "### Core Insurance Portals\n",
+      "- **Carllm** - Auto insurance platform for insurers\n",
+      "- **Homellm** - Home insurance platform for insurers\n",
+      "- **Lifellm** - Life insurance platform with AI-powered underwriting\n",
+      "- **Healthllm** - Comprehensive health insurance platform\n",
+      "- **Bizllm** - Commercial insurance platform for business coverage\n",
+      "\n",
+      "### Marketplace & Infrastructure\n",
+      "- **Markellm** - Marketplace connecting consumers with insurance providers (original flagship product)\n",
+      "- **Claimllm** - AI-powered claims processing platform across all insurance lines\n",
+      "- **Rellm** - Enterprise platform for the reinsurance sector\n",
+      "   sources: ['company\\\\about.md', 'company\\\\overview.md', 'contracts\\\\Contract with EverGuard Insurance for Rellm - AI-Powered Enterprise Reinsurance Solution.md', 'contracts\\\\Contract with National Claims Network for Claimllm.md']\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def rag_answer(question, k=4):\n",
+    "    hits = collection.query(query_texts=[question], n_results=k)   # retrieve top-k relevant docs\n",
+    "    context = \"\\n\\n---\\n\\n\".join(hits[\"documents\"][0])             # stitch them into context\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": \"Answer using ONLY the context. If it's not there, say you don't know.\"},\n",
+    "        {\"role\": \"user\", \"content\": f\"Context:\\n{context}\\n\\nQuestion: {question}\"},\n",
+    "    ]\n",
+    "    answer = frontier.chat.completions.create(model=\"gpt-4o-mini\", messages=messages).choices[0].message.content\n",
+    "    return answer, ids_from(hits)\n",
+    "\n",
+    "def ids_from(hits):\n",
+    "    return hits[\"ids\"][0]\n",
+    "\n",
+    "for q in [\"Who is the CEO of Insurellm?\", \"What products does Insurellm offer?\"]:\n",
+    "    ans, sources = rag_answer(q)\n",
+    "    print(f\"Q: {q}\\nA: {ans}\\n   sources: {sources}\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week6/curate.py
+++ b/community-contributions/NicholasDean/week6/curate.py
@@ -1,0 +1,52 @@
+"""Curate Amazon-Reviews-2023 product data into train/test Items (reuses the course's
+pricer parser). Optional per-category row cap keeps a small, RAM-friendly working set.
+
+  # full course-scale curation (large: ~2.9M items, ~9GB pickle, needs lots of RAM to load):
+  uv run python community-contributions/NicholasDean/week6/curate.py ALL data_full.pkl
+  # small mixed working subset for the fine-tune (fast, cached datasets, ~MBs):
+  uv run python community-contributions/NicholasDean/week6/curate.py ALL data_small.pkl 5000
+"""
+import sys, pickle, random
+from pathlib import Path
+
+REPO = next(p for p in Path(__file__).resolve().parents if (p / "week6" / "pricer" / "parser.py").exists())
+sys.path.insert(0, str(REPO / "week6"))
+from datasets import load_dataset      # noqa: E402
+from pricer.parser import parse        # noqa: E402
+
+CATEGORIES = ["Appliances", "Automotive", "Cell_Phones_and_Accessories", "Electronics",
+              "Musical_Instruments", "Office_Products", "Tools_and_Home_Improvement", "Toys_and_Games"]
+
+
+def load_category(cat, limit=None):
+    ds = load_dataset("McAuley-Lab/Amazon-Reviews-2023", f"raw_meta_{cat}", split="full", trust_remote_code=True)
+    if limit:
+        ds = ds.select(range(min(limit, len(ds))))   # cap rows BEFORE parsing -> fast + small
+    return [it for it in (parse(d, cat) for d in ds) if it is not None]
+
+
+def main(cats, out, limit=None):
+    items = []
+    for c in cats:
+        got = load_category(c, limit)
+        print(f"{c}: {len(got):,}", flush=True)
+        items += got
+    for it in items:
+        it.make_prompt(it.full)                      # build "...Price is $X.00" training prompt
+    random.seed(42)
+    random.shuffle(items)
+    n_test = min(2000, len(items) // 5)
+    test, train = items[:n_test], items[n_test:]
+    out_path = Path(__file__).parent / out
+    with open(out_path, "wb") as f:
+        pickle.dump({"train": [i.model_dump() for i in train],
+                     "test": [i.model_dump() for i in test]}, f)
+    print(f"curated {len(items):,} items -> {len(train):,} train / {len(test):,} test -> {out_path}", flush=True)
+
+
+if __name__ == "__main__":
+    arg = sys.argv[1] if len(sys.argv) > 1 else "Appliances"
+    cats = CATEGORIES if arg.upper() == "ALL" else arg.split(",")
+    out = sys.argv[2] if len(sys.argv) > 2 else "data.pkl"
+    limit = int(sys.argv[3]) if len(sys.argv) > 3 else None
+    main(cats, out, limit)

--- a/community-contributions/NicholasDean/week6/week6_exercise.ipynb
+++ b/community-contributions/NicholasDean/week6/week6_exercise.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b7f8cb63",
+   "metadata": {},
+   "source": [
+    "# Week 6 exercise — fine-tuning (\"The Price Is Right\")\n",
+    "\n",
+    "Predict a product's price from its description. We curate the Amazon-Reviews data\n",
+    "(`curate.py`, reusing the course `pricer` package), measure a **zero-shot** baseline, then\n",
+    "**fine-tune** a model on the task.\n",
+    "\n",
+    "> The course fine-tuned `gpt-4o-mini` via OpenAI's API, but OpenAI **deprecated/wound down\n",
+    "> API fine-tuning** (403 `training_not_available`). Gemini tuning needs Vertex/GCP, not just\n",
+    "> an API key. So we fine-tune a **local open-source** model (`distilgpt2` + LoRA on CPU) —\n",
+    "> Week 7's technique, brought forward. Run `curate.py ALL data_small.pkl 5000` first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "50d244c9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T14:41:58.802192Z",
+     "iopub.status.busy": "2026-06-23T14:41:58.802192Z",
+     "iopub.status.idle": "2026-06-23T14:42:07.123582Z",
+     "shell.execute_reply": "2026-06-23T14:42:07.123078Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys, pickle, re, random\n",
+    "from pathlib import Path\n",
+    "import torch\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer\n",
+    "from peft import LoraConfig, get_peft_model\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "openai = OpenAI()\n",
+    "REPO = next(p for p in [Path.cwd(), *Path.cwd().parents] if (p / \"week6/pricer/items.py\").exists())\n",
+    "sys.path.insert(0, str(REPO / \"week6\"))\n",
+    "from pricer.items import Item  # noqa: E402\n",
+    "HERE = REPO / \"community-contributions/NicholasDean/week6\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "93f85080",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T14:42:07.125583Z",
+     "iopub.status.busy": "2026-06-23T14:42:07.125083Z",
+     "iopub.status.idle": "2026-06-23T14:42:07.338477Z",
+     "shell.execute_reply": "2026-06-23T14:42:07.337971Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "train=16,801  test=2,000\n"
+     ]
+    }
+   ],
+   "source": [
+    "blob = pickle.load(open(HERE / \"data_small.pkl\", \"rb\"))   # mixed subset (full curation = data_full.pkl, ~9GB)\n",
+    "train = [Item.model_validate(d) for d in blob[\"train\"]]\n",
+    "test = [Item.model_validate(d) for d in blob[\"test\"]]\n",
+    "SAMPLE = test[:50]\n",
+    "print(f\"train={len(train):,}  test={len(test):,}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bde15764",
+   "metadata": {},
+   "source": [
+    "## Zero-shot baseline (frontier reference)\n",
+    "`gpt-4o-mini`, no training. Hit = within 20% or $40 of the true price."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b6fd4142",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T14:42:07.339978Z",
+     "iopub.status.busy": "2026-06-23T14:42:07.339978Z",
+     "iopub.status.idle": "2026-06-23T14:42:50.905279Z",
+     "shell.execute_reply": "2026-06-23T14:42:50.904771Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "zero-shot gpt-4o-mini:  MAE=$22.80  hit-rate=86%\n"
+     ]
+    }
+   ],
+   "source": [
+    "SYSTEM = \"You estimate the price of products. Reply with just the price, e.g. 'Price is $9.00'.\"\n",
+    "\n",
+    "def get_price(text):\n",
+    "    nums = re.findall(r\"[-+]?\\d*\\.?\\d+\", text.replace(\",\", \"\"))   # first number in the text\n",
+    "    return float(nums[0]) if nums else 0.0\n",
+    "\n",
+    "def score(errs, items):\n",
+    "    hits = sum(e <= 0.2 * it.price or e <= 40 for e, it in zip(errs, items))\n",
+    "    return sum(errs) / len(errs), hits / len(items)\n",
+    "\n",
+    "def gpt_price(item):\n",
+    "    r = openai.chat.completions.create(model=\"gpt-4o-mini\", seed=42, max_tokens=8,\n",
+    "        messages=[{\"role\": \"system\", \"content\": SYSTEM}, {\"role\": \"user\", \"content\": item.test_prompt()}])\n",
+    "    return get_price(r.choices[0].message.content)\n",
+    "\n",
+    "mae0, hit0 = score([abs(gpt_price(it) - it.price) for it in SAMPLE], SAMPLE)\n",
+    "print(f\"zero-shot gpt-4o-mini:  MAE=${mae0:,.2f}  hit-rate={hit0:.0%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eacc99c8",
+   "metadata": {},
+   "source": [
+    "## Fine-tune distilgpt2 with LoRA (local, CPU)\n",
+    "LoRA trains tiny adapter weights (~0.2% of params), so it's cheap. We train on the curated\n",
+    "prompts (each ends with `Price is $X.00`). Left-truncation keeps that price suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b221ecb1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T14:42:50.906778Z",
+     "iopub.status.busy": "2026-06-23T14:42:50.906778Z",
+     "iopub.status.idle": "2026-06-23T14:44:33.192447Z",
+     "shell.execute_reply": "2026-06-23T14:44:33.191433Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Nicholas Dean\\projects\\llm_engineering\\.venv\\Lib\\site-packages\\peft\\tuners\\lora\\layer.py:2504: UserWarning: fan_in_fan_out is set to False but the target module is `Conv1D`. Setting fan_in_fan_out to True.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trainable params: 147,456 || all params: 82,060,032 || trainable%: 0.1797\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "`loss_type=None` was set in the config but it is unrecognized. Using the default loss: `ForCausalLMLoss`.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 1 done\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 2 done\n"
+     ]
+    }
+   ],
+   "source": [
+    "tok = AutoTokenizer.from_pretrained(\"distilgpt2\")\n",
+    "tok.pad_token = tok.eos_token\n",
+    "tok.truncation_side = \"left\"                       # keep the END of the prompt (the price target)\n",
+    "model = get_peft_model(AutoModelForCausalLM.from_pretrained(\"distilgpt2\"),\n",
+    "                       LoraConfig(r=8, lora_alpha=16, target_modules=[\"c_attn\"], task_type=\"CAUSAL_LM\"))\n",
+    "model.print_trainable_parameters()\n",
+    "\n",
+    "texts = [it.prompt for it in train[:150]]          # full training prompts\n",
+    "opt = torch.optim.AdamW(model.parameters(), lr=2e-4)\n",
+    "model.train()\n",
+    "for epoch in range(2):\n",
+    "    random.Random(epoch).shuffle(texts)\n",
+    "    for txt in texts:\n",
+    "        enc = tok(txt, return_tensors=\"pt\", truncation=True, max_length=220)\n",
+    "        enc[\"labels\"] = enc[\"input_ids\"]\n",
+    "        model(**enc).loss.backward()\n",
+    "        opt.step(); opt.zero_grad()\n",
+    "    print(f\"epoch {epoch + 1} done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eeb99dbb",
+   "metadata": {},
+   "source": [
+    "## Compare: base distilgpt2 vs fine-tuned vs frontier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "30f50d8a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T14:44:33.194454Z",
+     "iopub.status.busy": "2026-06-23T14:44:33.193954Z",
+     "iopub.status.idle": "2026-06-23T14:45:02.558202Z",
+     "shell.execute_reply": "2026-06-23T14:45:02.557197Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "base distilgpt2:       MAE=$97.36  hit-rate=70%\n",
+      "fine-tuned distilgpt2: MAE=$52.78  hit-rate=76%\n",
+      "gpt-4o-mini zero-shot: MAE=$22.80  hit-rate=86%  (frontier reference)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def local_price(item):\n",
+    "    enc = tok(item.test_prompt(), return_tensors=\"pt\", truncation=True, max_length=220)\n",
+    "    with torch.no_grad():\n",
+    "        out = model.generate(**enc, max_new_tokens=8, do_sample=False, pad_token_id=tok.eos_token_id)\n",
+    "    return get_price(tok.decode(out[0][enc[\"input_ids\"].shape[1]:], skip_special_tokens=True))\n",
+    "\n",
+    "def eval_local(items):\n",
+    "    return score([abs(local_price(it) - it.price) for it in items], items)\n",
+    "\n",
+    "model.eval()\n",
+    "mae_ft, hit_ft = eval_local(SAMPLE)                      # adapters ON (fine-tuned)\n",
+    "with model.disable_adapter():\n",
+    "    mae_base, hit_base = eval_local(SAMPLE)              # adapters OFF (base distilgpt2)\n",
+    "\n",
+    "print(f\"base distilgpt2:       MAE=${mae_base:,.2f}  hit-rate={hit_base:.0%}\")\n",
+    "print(f\"fine-tuned distilgpt2: MAE=${mae_ft:,.2f}  hit-rate={hit_ft:.0%}\")\n",
+    "print(f\"gpt-4o-mini zero-shot: MAE=${mae0:,.2f}  hit-rate={hit0:.0%}  (frontier reference)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week7/week7_exercise.ipynb
+++ b/community-contributions/NicholasDean/week7/week7_exercise.ipynb
@@ -1,0 +1,285 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6bb327ff",
+   "metadata": {},
+   "source": [
+    "# Week 7 exercise — QLoRA on a local GPU (\"The Price Is Right\", scaled up)\n",
+    "\n",
+    "Week 6 fine-tuned a tiny model on CPU. Week 7 adds **4-bit quantization (QLoRA)** so a\n",
+    "much bigger open model fits on a modest GPU. Here: load **Qwen2.5-1.5B-Instruct** in 4-bit\n",
+    "on an 8GB RTX 2070, QLoRA-fine-tune it on the pricing data, and compare to the base model\n",
+    "and the frontier reference.\n",
+    "\n",
+    "> Needs **CUDA torch + bitsandbytes** in the venv. Run with that env (note: `uv run`\n",
+    "> re-syncs to CPU torch — use the venv Python directly)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ab3e635c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T15:56:41.095827Z",
+     "iopub.status.busy": "2026-06-23T15:56:41.095827Z",
+     "iopub.status.idle": "2026-06-23T15:56:48.625882Z",
+     "shell.execute_reply": "2026-06-23T15:56:48.624877Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cuda: NVIDIA GeForce RTX 2070 SUPER | train: 16801\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys, pickle, re, random\n",
+    "from pathlib import Path\n",
+    "import torch\n",
+    "from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig\n",
+    "from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training\n",
+    "\n",
+    "REPO = next(p for p in [Path.cwd(), *Path.cwd().parents] if (p / \"week6/pricer/items.py\").exists())\n",
+    "sys.path.insert(0, str(REPO / \"week6\"))\n",
+    "from pricer.items import Item  # noqa: E402\n",
+    "DATA = REPO / \"community-contributions/NicholasDean/week6/data_small.pkl\"  # reuse week 6 curation\n",
+    "\n",
+    "blob = pickle.load(open(DATA, \"rb\"))\n",
+    "train = [Item.model_validate(d) for d in blob[\"train\"]]\n",
+    "SAMPLE = [Item.model_validate(d) for d in blob[\"test\"][:50]]\n",
+    "print(\"cuda:\", torch.cuda.get_device_name(0), \"| train:\", len(train))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "544a2d2b",
+   "metadata": {},
+   "source": [
+    "## Load Qwen2.5-1.5B in 4-bit (QLoRA)\n",
+    "4-bit NF4 quantization shrinks the weights ~4x; float16 compute (Turing GPU has no bf16)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "dba7655c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T15:56:48.627386Z",
+     "iopub.status.busy": "2026-06-23T15:56:48.627386Z",
+     "iopub.status.idle": "2026-06-23T15:56:53.683166Z",
+     "shell.execute_reply": "2026-06-23T15:56:53.682161Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "W0623 11:56:50.141000 35292 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "trainable params: 18,464,768 || all params: 1,562,179,072 || trainable%: 1.1820\n",
+      "VRAM after load (GB): 1.75\n"
+     ]
+    }
+   ],
+   "source": [
+    "MODEL = \"Qwen/Qwen2.5-1.5B-Instruct\"\n",
+    "bnb = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_quant_type=\"nf4\", bnb_4bit_compute_dtype=torch.float16)\n",
+    "tok = AutoTokenizer.from_pretrained(MODEL)\n",
+    "tok.pad_token = tok.pad_token or tok.eos_token\n",
+    "tok.truncation_side = \"left\"                          # keep the END (the price target)\n",
+    "model = AutoModelForCausalLM.from_pretrained(MODEL, quantization_config=bnb, device_map=\"cuda\")\n",
+    "model = prepare_model_for_kbit_training(model)\n",
+    "model = get_peft_model(model, LoraConfig(r=16, lora_alpha=32, task_type=\"CAUSAL_LM\",\n",
+    "        target_modules=[\"q_proj\", \"k_proj\", \"v_proj\", \"o_proj\", \"gate_proj\", \"up_proj\", \"down_proj\"]))\n",
+    "model.print_trainable_parameters()\n",
+    "print(\"VRAM after load (GB):\", round(torch.cuda.memory_allocated() / 1e9, 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26c56f90",
+   "metadata": {},
+   "source": [
+    "## QLoRA fine-tune (on the GPU)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "35aa26a8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T15:56:53.685173Z",
+     "iopub.status.busy": "2026-06-23T15:56:53.684673Z",
+     "iopub.status.idle": "2026-06-23T16:26:33.781291Z",
+     "shell.execute_reply": "2026-06-23T16:26:33.780786Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Nicholas Dean\\projects\\llm_engineering\\.venv\\Lib\\site-packages\\torch\\_dynamo\\eval_frame.py:1263: UserWarning: torch.utils.checkpoint: the use_reentrant parameter should be passed explicitly. Starting in PyTorch 2.9, calling checkpoint without use_reentrant will raise an exception. use_reentrant=False is recommended, but if you need to preserve the current default behavior, you can pass use_reentrant=True. Refer to docs for more details on the differences between the two variants.\n",
+      "  return fn(*args, **kwargs)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 1 done\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 2 done\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 3 done\n",
+      "peak VRAM (GB): 2.49\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch as _t\n",
+    "\n",
+    "def example(it):\n",
+    "    # prompt ends with 'Price is $'; answer is the price -> mask labels so we train only the answer\n",
+    "    p = tok(it.test_prompt(), truncation=True, max_length=210)[\"input_ids\"]\n",
+    "    a = tok(f\"{round(it.price)}.00\" + tok.eos_token, add_special_tokens=False)[\"input_ids\"]\n",
+    "    return p + a, [-100] * len(p) + a\n",
+    "\n",
+    "data = [example(it) for it in train[:1200]]\n",
+    "opt = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=2e-4)\n",
+    "model.train()\n",
+    "for epoch in range(3):\n",
+    "    random.Random(epoch).shuffle(data)\n",
+    "    for ids, labels in data:\n",
+    "        ids_t = _t.tensor([ids], device=\"cuda\")\n",
+    "        out = model(input_ids=ids_t, labels=_t.tensor([labels], device=\"cuda\"))\n",
+    "        out.loss.backward()\n",
+    "        opt.step(); opt.zero_grad()\n",
+    "    print(f\"epoch {epoch + 1} done\")\n",
+    "print(\"peak VRAM (GB):\", round(torch.cuda.max_memory_allocated() / 1e9, 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ec5afab",
+   "metadata": {},
+   "source": [
+    "## Compare: base Qwen vs QLoRA-fine-tuned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b01709a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T16:26:33.783291Z",
+     "iopub.status.busy": "2026-06-23T16:26:33.782793Z",
+     "iopub.status.idle": "2026-06-23T16:27:50.065107Z",
+     "shell.execute_reply": "2026-06-23T16:27:50.064598Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "The following generation flags are not valid and may be ignored: ['temperature', 'top_p', 'top_k']. Set `TRANSFORMERS_VERBOSITY=info` for more details.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Nicholas Dean\\projects\\llm_engineering\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "base Qwen2.5-1.5B (4-bit):   MAE=$47.82  hit-rate=70%\n",
+      "QLoRA fine-tuned Qwen-1.5B:   MAE=$42.71  hit-rate=80%\n",
+      "references -> week6 distilgpt2 LoRA: $52.78 (76%) | gpt-4o-mini zero-shot: $22.80 (86%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def get_price(text):\n",
+    "    nums = re.findall(r\"[-+]?\\d*\\.?\\d+\", text.replace(\",\", \"\"))\n",
+    "    return float(nums[0]) if nums else 0.0\n",
+    "\n",
+    "def local_price(item):\n",
+    "    enc = tok(item.test_prompt(), return_tensors=\"pt\", truncation=True, max_length=220).to(\"cuda\")\n",
+    "    with torch.no_grad():\n",
+    "        out = model.generate(**enc, max_new_tokens=8, do_sample=False, pad_token_id=tok.eos_token_id)\n",
+    "    return get_price(tok.decode(out[0][enc[\"input_ids\"].shape[1]:], skip_special_tokens=True))\n",
+    "\n",
+    "def evaluate(items):\n",
+    "    errs = [abs(local_price(it) - it.price) for it in items]\n",
+    "    hits = sum(e <= 0.2 * it.price or e <= 40 for e, it in zip(errs, items))\n",
+    "    return sum(errs) / len(errs), hits / len(items)\n",
+    "\n",
+    "model.eval()\n",
+    "mae_ft, hit_ft = evaluate(SAMPLE)\n",
+    "with model.disable_adapter():\n",
+    "    mae_base, hit_base = evaluate(SAMPLE)\n",
+    "print(f\"base Qwen2.5-1.5B (4-bit):   MAE=${mae_base:,.2f}  hit-rate={hit_base:.0%}\")\n",
+    "print(f\"QLoRA fine-tuned Qwen-1.5B:   MAE=${mae_ft:,.2f}  hit-rate={hit_ft:.0%}\")\n",
+    "print(\"references -> week6 distilgpt2 LoRA: $52.78 (76%) | gpt-4o-mini zero-shot: $22.80 (86%)\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/community-contributions/NicholasDean/week8/grocery_agents.py
+++ b/community-contributions/NicholasDean/week8/grocery_agents.py
@@ -1,0 +1,93 @@
+"""Week 8 capstone — a multi-agent grocery deal-finder (Hannaford vs Market Basket).
+
+Mirrors the course's pattern: a PlanningAgent orchestrates specialist agents
+(Scanner -> Pricers -> Reporter). Each agent is a small role around an LLM call.
+
+NOTE: prices are gpt-4o-mini ESTIMATES (general knowledge of New England grocery prices),
+not live data. A production version would plug live store APIs/flyers into the Scanner and
+Pricer agents — the agent architecture stays the same.
+"""
+import json
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+client = OpenAI()
+MODEL = "gpt-4o-mini"
+STORES = ["Hannaford", "Market Basket"]
+
+
+class Agent:
+    """Base agent: a role that calls the LLM (optionally in JSON mode)."""
+    name = "Agent"
+
+    def chat(self, system, user, json_mode=False):
+        kw = {"response_format": {"type": "json_object"}} if json_mode else {}
+        r = client.chat.completions.create(model=MODEL, messages=[
+            {"role": "system", "content": system}, {"role": "user", "content": user}], **kw)
+        return r.choices[0].message.content
+
+
+class ScannerAgent(Agent):
+    """Produces the shopping basket. (Production: scrape weekly flyers / specials.)"""
+    name = "Scanner"
+    BASKET = ["1 gallon whole milk", "one dozen large eggs", "loaf of white sandwich bread",
+              "2 lb bananas", "1 lb boneless chicken breast", "8 oz block cheddar cheese",
+              "12 oz bag ground coffee", "1 lb butter", "64 oz orange juice", "18 oz peanut butter"]
+
+    def run(self):
+        return self.BASKET
+
+
+class PricerAgent(Agent):
+    """Estimates one store's prices for the basket. (Production: live store API/scrape.)"""
+    name = "Pricer"
+
+    def __init__(self, store):
+        self.store = store
+
+    def run(self, items):
+        system = (f"You are a grocery pricing expert for {self.store} supermarkets in New England. "
+                  "Give realistic current shelf prices in USD. Market Basket is known for low prices.")
+        user = ("Return ONLY a JSON object mapping each item EXACTLY to its price as a number (USD) "
+                f"at {self.store}. Items: {json.dumps(items)}")
+        return json.loads(self.chat(system, user, json_mode=True))
+
+
+class PlanningAgent(Agent):
+    """Orchestrates the scan + both pricers, then compares to find the cheaper store per item."""
+    name = "Planner"
+
+    def run(self):
+        items = ScannerAgent().run()
+        prices = {s: PricerAgent(s).run(items) for s in STORES}
+        rows = []
+        for it in items:
+            p = {s: float(prices[s].get(it, 0) or 0) for s in STORES}
+            cheaper = min(STORES, key=lambda s: p[s])
+            rows.append({"item": it, **p, "cheaper": cheaper, "savings": round(abs(p[STORES[0]] - p[STORES[1]]), 2)})
+        totals = {s: round(sum(r[s] for r in rows), 2) for s in STORES}
+        optimal = round(sum(min(r[STORES[0]], r[STORES[1]]) for r in rows), 2)  # buy each item at its cheaper store
+        return {"rows": rows, "totals": totals, "optimal": optimal}
+
+
+class ReportAgent(Agent):
+    """Writes a short shopping recommendation from the comparison."""
+    name = "Reporter"
+
+    def run(self, plan):
+        user = ("Write a concise grocery shopping recommendation (4-5 sentences) from this "
+                "Hannaford vs Market Basket comparison. Say which store is cheaper overall, the "
+                "total savings, and 2-3 items with the biggest difference. Data:\n" + json.dumps(plan))
+        return self.chat("You are a frugal shopping assistant.", user)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.stdout.reconfigure(encoding="utf-8")
+    plan = PlanningAgent().run()
+    for r in plan["rows"]:
+        print(f"  {r['item']:<32} H ${r['Hannaford']:>5.2f}  MB ${r['Market Basket']:>5.2f}  -> {r['cheaper']}")
+    print("totals:", plan["totals"], "| optimal split: $", plan["optimal"])
+    print("\n" + ReportAgent().run(plan))

--- a/community-contributions/NicholasDean/week8/week8_exercise.ipynb
+++ b/community-contributions/NicholasDean/week8/week8_exercise.ipynb
@@ -1,0 +1,255 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3a2bffec",
+   "metadata": {},
+   "source": [
+    "# Week 8 capstone — autonomous multi-agent deal-finder (Hannaford vs Market Basket)\n",
+    "\n",
+    "The week-8 pattern: a **PlanningAgent** orchestrates specialist agents — a **Scanner**\n",
+    "(the shopping basket), two **Pricer** agents (one per store), and a **Reporter** that writes\n",
+    "the recommendation. Applied to my real local stores.\n",
+    "\n",
+    "> Prices are `gpt-4o-mini` **estimates**, not live data — a production version plugs live\n",
+    "> store APIs/flyers into the Scanner & Pricer agents; the agent architecture is unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0acfafdb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:46:05.592414Z",
+     "iopub.status.busy": "2026-06-23T17:46:05.592414Z",
+     "iopub.status.idle": "2026-06-23T17:46:18.387311Z",
+     "shell.execute_reply": "2026-06-23T17:46:18.386808Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>item</th>\n",
+       "      <th>Hannaford</th>\n",
+       "      <th>Market Basket</th>\n",
+       "      <th>cheaper</th>\n",
+       "      <th>savings</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1 gallon whole milk</td>\n",
+       "      <td>4.49</td>\n",
+       "      <td>3.49</td>\n",
+       "      <td>Market Basket</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>one dozen large eggs</td>\n",
+       "      <td>2.99</td>\n",
+       "      <td>2.99</td>\n",
+       "      <td>Hannaford</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>loaf of white sandwich bread</td>\n",
+       "      <td>2.49</td>\n",
+       "      <td>1.99</td>\n",
+       "      <td>Market Basket</td>\n",
+       "      <td>0.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2 lb bananas</td>\n",
+       "      <td>1.99</td>\n",
+       "      <td>1.49</td>\n",
+       "      <td>Market Basket</td>\n",
+       "      <td>0.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1 lb boneless chicken breast</td>\n",
+       "      <td>4.99</td>\n",
+       "      <td>5.99</td>\n",
+       "      <td>Hannaford</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>8 oz block cheddar cheese</td>\n",
+       "      <td>3.49</td>\n",
+       "      <td>2.49</td>\n",
+       "      <td>Market Basket</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>12 oz bag ground coffee</td>\n",
+       "      <td>7.99</td>\n",
+       "      <td>6.99</td>\n",
+       "      <td>Market Basket</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>1 lb butter</td>\n",
+       "      <td>3.89</td>\n",
+       "      <td>4.29</td>\n",
+       "      <td>Hannaford</td>\n",
+       "      <td>0.4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>64 oz orange juice</td>\n",
+       "      <td>3.49</td>\n",
+       "      <td>3.99</td>\n",
+       "      <td>Hannaford</td>\n",
+       "      <td>0.5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>18 oz peanut butter</td>\n",
+       "      <td>3.29</td>\n",
+       "      <td>3.49</td>\n",
+       "      <td>Hannaford</td>\n",
+       "      <td>0.2</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                           item  Hannaford  Market Basket        cheaper  \\\n",
+       "0           1 gallon whole milk       4.49           3.49  Market Basket   \n",
+       "1          one dozen large eggs       2.99           2.99      Hannaford   \n",
+       "2  loaf of white sandwich bread       2.49           1.99  Market Basket   \n",
+       "3                  2 lb bananas       1.99           1.49  Market Basket   \n",
+       "4  1 lb boneless chicken breast       4.99           5.99      Hannaford   \n",
+       "5     8 oz block cheddar cheese       3.49           2.49  Market Basket   \n",
+       "6       12 oz bag ground coffee       7.99           6.99  Market Basket   \n",
+       "7                   1 lb butter       3.89           4.29      Hannaford   \n",
+       "8            64 oz orange juice       3.49           3.99      Hannaford   \n",
+       "9           18 oz peanut butter       3.29           3.49      Hannaford   \n",
+       "\n",
+       "   savings  \n",
+       "0      1.0  \n",
+       "1      0.0  \n",
+       "2      0.5  \n",
+       "3      0.5  \n",
+       "4      1.0  \n",
+       "5      1.0  \n",
+       "6      1.0  \n",
+       "7      0.4  \n",
+       "8      0.5  \n",
+       "9      0.2  "
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "\n",
+    "REPO = next(p for p in [Path.cwd(), *Path.cwd().parents] if (p / \"week6/pricer/items.py\").exists())\n",
+    "sys.path.insert(0, str(REPO / \"community-contributions/NicholasDean/week8\"))\n",
+    "from grocery_agents import PlanningAgent, ReportAgent  # noqa: E402\n",
+    "\n",
+    "plan = PlanningAgent().run()           # Scanner -> two Pricers -> compare\n",
+    "pd.DataFrame(plan[\"rows\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e7146c",
+   "metadata": {},
+   "source": [
+    "## Totals and the recommendation (Reporter agent)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8cf84d52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-23T17:46:18.388812Z",
+     "iopub.status.busy": "2026-06-23T17:46:18.388812Z",
+     "iopub.status.idle": "2026-06-23T17:46:20.126249Z",
+     "shell.execute_reply": "2026-06-23T17:46:20.125743Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Basket totals: {'Hannaford': 39.1, 'Market Basket': 37.2}\n",
+      "Optimal (buy each item at its cheaper store): $ 35.1\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "For an overall cheaper grocery shopping experience, Market Basket is the better option, offering total savings of $1.90 compared to Hannaford. Notable price differences include 1 gallon of whole milk, which is $1.00 less at Market Basket, and a loaf of white sandwich bread that saves you $0.50 at Market Basket as well. Additionally, 2 lb of bananas also has a $0.50 savings at Market Basket. To maximize savings, consider shopping at Market Basket.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Basket totals:\", plan[\"totals\"])\n",
+    "print(\"Optimal (buy each item at its cheaper store): $\", plan[\"optimal\"])\n",
+    "print()\n",
+    "print(ReportAgent().run(plan))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (llms .venv)",
+   "language": "python",
+   "name": "llms"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
My solutions to the end-of-week exercises for weeks 1–8, under `community-contributions/NicholasDean/`.

- **Week 1:** technical-question explainer (gpt-4o-mini + llama3.2 via one OpenAI-compatible client)
- **Week 2:** Gradio technical tutor — streaming + model switching (gpt-4o-mini / claude / llama3.2)
- **Week 3:** open-source models locally — tokenizer comparison + a summarizer "meeting minutes" (CPU)
- **Week 4:** Python→C++ code generator with model comparison, compiled + benchmarked
- **Week 5:** RAG over the knowledge base with Chroma (local embeddings) + sources
- **Week 6:** "Price Is Right" — data curation + zero-shot baseline + LoRA fine-tune (local pivot, since OpenAI API fine-tuning is deprecated)
- **Week 7:** QLoRA (4-bit) fine-tune of Qwen2.5-1.5B on a single 8GB GPU
- **Week 8:** a multi-agent capstone — a local-grocery deal-finder (planner orchestrates scanner → pricers → reporter)

All notebooks were executed locally. `week6/curate.py` and `week8/grocery_agents.py` are helper modules the notebooks import.