### PR TITLE
fix: replace dead dall-e-3 with gpt-image-1-mini

### DIFF
--- a/week2/day5.ipynb
+++ b/week2/day5.ipynb
@@ -218,11 +218,11 @@
    "source": [
     "# Let's go multi-modal!!\n",
     "\n",
-    "We can use DALL-E-3, the image generation model behind GPT-4o, to make us some images\n",
+    "We can use gpt-image-1-mini, the image generation model behind GPT-5, to make us some images\n",
     "\n",
     "Let's put this in a function called artist.\n",
     "\n",
-    "### Price alert: each time I generate an image it costs about 4 cents - don't go crazy with images!"
+    "### Price alert: each time I generate an image it costs about 3 cents - don't go crazy with images!"
    ]
   },
   {
@@ -248,11 +248,10 @@
    "source": [
     "def artist(city):\n",
     "    image_response = openai.images.generate(\n",
-    "            model=\"dall-e-3\",\n",
+    "            model=\"gpt-image-1-mini\",\n",
     "            prompt=f\"An image representing a vacation in {city}, showing tourist spots and everything unique about {city}, in a vibrant pop-art style\",\n",
     "            size=\"1024x1024\",\n",
     "            n=1,\n",
-    "            response_format=\"b64_json\",\n",
     "        )\n",
     "    image_base64 = image_response.data[0].b64_json\n",
     "    image_data = base64.b64decode(image_base64)\n",


### PR DESCRIPTION
Attempts to use DALL-E-3 thows errors.
**DALL-E-3 reached EOL 2026-05-12**: https://community.openai.com/t/openai-is-making-a-huge-mistake-by-deprecating-dall-e-3/1367228

`gpt-image-1-mini` is the closest (cheap, suitable for the course) analogue available today. Newer models no longer support "response_format": 

> This parameter isn’t supported for the GPT image models, which always return base64-encoded images.

 https://developers.openai.com/api/reference/python/resources/images/methods/generate#(resource)%20images%20%3E%20(method)%20generate%20%3E%20(params)%20default.non_streaming%20%3E%20(param)%20response_format%20%3E%20(schema)

<img width="1359" height="1269" alt="image" src="https://github.com/user-attachments/assets/6db4d994-c8c5-4dcc-b2d2-c2e60a863de4" />
