### PR TITLE
Adds an accessibility repo tracker

### DIFF
--- a/week2/community-contributions/Accessibility_Repo_Tracker.ipynb
+++ b/week2/community-contributions/Accessibility_Repo_Tracker.ipynb
@@ -1,0 +1,351 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "art13b53c0b",
+   "metadata": {},
+   "source": [
+    "# Accessibility Repo Tracker\n",
+    "\n",
+    "The GitHub API exposes open issues, pull requests, and release notes for any public repository. This notebook wraps it for accessibility-related repos — axe-core, eslint-plugin-jsx-a11y, and NVDA — so you can ask \"are there any open axe-core issues related to combobox keyboard handling?\" or \"what changed in the latest eslint-plugin-jsx-a11y release?\" without leaving your workflow. Directly useful for a daily PR-review habit.\n",
+    "\n",
+    "## How it works\n",
+    "\n",
+    "The model is given two tools:\n",
+    "- `search_repo_issues(repo, query)` — searches open issues/PRs in a repo for a keyword.\n",
+    "- `get_latest_release(repo)` — fetches the latest release notes for a repo.\n",
+    "\n",
+    "The model picks the right tool (and `repo`) based on the question, and can call either one — even multiple times in one turn — across a conversation as you ask about different repos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "art2d362ff4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "\n",
+    "import os\n",
+    "import json\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "art6f4003b7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Anthropic API Key exists and begins sk-ant-a\n",
+      "GitHub token exists and begins ghp_\n"
+     ]
+    }
+   ],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')\n",
+    "github_token = os.getenv('GITHUB_TOKEN')\n",
+    "\n",
+    "if anthropic_api_key:\n",
+    "    print(f\"Anthropic API Key exists and begins {anthropic_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"Anthropic API Key not set\")\n",
+    "\n",
+    "if github_token:\n",
+    "    print(f\"GitHub token exists and begins {github_token[:4]}\")\n",
+    "else:\n",
+    "    print(\"GitHub token not set — requests will be rate-limited to 60/hour without one\")\n",
+    "\n",
+    "openai = OpenAI(\n",
+    "    api_key=anthropic_api_key,\n",
+    "    base_url=\"https://api.anthropic.com/v1/\",\n",
+    ")\n",
+    "MODEL = \"claude-sonnet-4-6\"\n",
+    "\n",
+    "GITHUB_HEADERS = {\"Accept\": \"application/vnd.github+json\"}\n",
+    "if github_token:\n",
+    "    GITHUB_HEADERS[\"Authorization\"] = f\"Bearer {github_token}\"\n",
+    "\n",
+    "ACCESSIBILITY_REPOS = {\n",
+    "    \"axe-core\": \"dequelabs/axe-core\",\n",
+    "    \"eslint-plugin-jsx-a11y\": \"jsx-eslint/eslint-plugin-jsx-a11y\",\n",
+    "    \"nvda\": \"nvaccess/nvda\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "art0d1670aa",
+   "metadata": {},
+   "source": "## Step 1: GitHub tool functions and tool schemas\n\nDefines `resolve_repo()` to map friendly names to `owner/name` slugs, `search_repo_issues()` to return up to 5 matching open issues, `get_latest_release()` to fetch the latest release metadata and notes, and the `tools` list with OpenAI-compatible function schemas for both."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "arteec58825",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def resolve_repo(repo):\n",
+    "    return ACCESSIBILITY_REPOS.get(repo.lower(), repo)\n",
+    "\n",
+    "def search_repo_issues(repo, query):\n",
+    "    full_repo = resolve_repo(repo)\n",
+    "    search_url = \"https://api.github.com/search/issues\"\n",
+    "    params = {\"q\": f\"repo:{full_repo} is:issue is:open {query}\"}\n",
+    "    response = requests.get(search_url, headers=GITHUB_HEADERS, params=params).json()\n",
+    "    items = response.get(\"items\", [])[:5]\n",
+    "    return [{\"title\": i[\"title\"], \"number\": i[\"number\"], \"url\": i[\"html_url\"],\n",
+    "             \"labels\": [l[\"name\"] for l in i.get(\"labels\", [])], \"created_at\": i[\"created_at\"]} for i in items]\n",
+    "\n",
+    "def get_latest_release(repo):\n",
+    "    full_repo = resolve_repo(repo)\n",
+    "    url = f\"https://api.github.com/repos/{full_repo}/releases/latest\"\n",
+    "    r = requests.get(url, headers=GITHUB_HEADERS).json()\n",
+    "    return {\"tag\": r.get(\"tag_name\"), \"name\": r.get(\"name\"), \"url\": r.get(\"html_url\"),\n",
+    "            \"published_at\": r.get(\"published_at\"), \"notes\": (r.get(\"body\") or \"\")[:1500]}\n",
+    "\n",
+    "search_issues_function = {\n",
+    "    \"name\": \"search_repo_issues\",\n",
+    "    \"description\": \"Search open issues and pull requests in an accessibility-related GitHub repo by keyword.\",\n",
+    "    \"parameters\": {\n",
+    "        \"type\": \"object\",\n",
+    "        \"properties\": {\n",
+    "            \"repo\": {\"type\": \"string\", \"description\": \"Repo name: 'axe-core', 'eslint-plugin-jsx-a11y', 'nvda', or any 'owner/name'.\"},\n",
+    "            \"query\": {\"type\": \"string\", \"description\": \"Keyword(s) to search for in issue titles and bodies, e.g. 'combobox keyboard'.\"},\n",
+    "        },\n",
+    "        \"required\": [\"repo\", \"query\"],\n",
+    "        \"additionalProperties\": False,\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "latest_release_function = {\n",
+    "    \"name\": \"get_latest_release\",\n",
+    "    \"description\": \"Get the latest release notes for an accessibility-related GitHub repo.\",\n",
+    "    \"parameters\": {\n",
+    "        \"type\": \"object\",\n",
+    "        \"properties\": {\n",
+    "            \"repo\": {\"type\": \"string\", \"description\": \"Repo name: 'axe-core', 'eslint-plugin-jsx-a11y', 'nvda', or any 'owner/name'.\"},\n",
+    "        },\n",
+    "        \"required\": [\"repo\"],\n",
+    "        \"additionalProperties\": False,\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "tools = [{\"type\": \"function\", \"function\": search_issues_function}, {\"type\": \"function\", \"function\": latest_release_function}]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "art47c22118",
+   "metadata": {},
+   "source": "## Step 2: System prompt and tool dispatch\n\nDefines the `system_prompt` that configures the assistant as an accessibility GitHub tracker, and `handle_tool_call()` which iterates over `message.tool_calls`, dispatches each by name to the matching Python function, and returns a list of tool response messages."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "art0f08da8d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"You are an accessibility engineer's daily assistant, with live access to GitHub issues, pull \\\n",
+    "requests, and release notes for axe-core, eslint-plugin-jsx-a11y, and NVDA.\n",
+    "\n",
+    "Call search_repo_issues when the developer asks about open issues, bugs, or pull requests on a topic — \\\n",
+    "e.g. \"are there any open axe-core issues related to combobox keyboard handling?\"\n",
+    "\n",
+    "Call get_latest_release when the developer asks what changed in a recent release — e.g. \"what changed in \\\n",
+    "the latest eslint-plugin-jsx-a11y release?\"\n",
+    "\n",
+    "When summarizing issues, list each one with its number, title, and link, and group by label if labels are \\\n",
+    "informative. When summarizing release notes, pull out the highlights relevant to accessibility rather than \\\n",
+    "pasting the entire changelog verbatim.\n",
+    "\n",
+    "If a search returns no results, say so plainly.\"\"\"\n",
+    "\n",
+    "def handle_tool_call(message):\n",
+    "    results = []\n",
+    "    for tool_call in message.tool_calls:\n",
+    "        arguments = json.loads(tool_call.function.arguments)\n",
+    "        if tool_call.function.name == \"search_repo_issues\":\n",
+    "            result = search_repo_issues(**arguments)\n",
+    "        elif tool_call.function.name == \"get_latest_release\":\n",
+    "            result = get_latest_release(**arguments)\n",
+    "        results.append({\n",
+    "            \"role\": \"tool\",\n",
+    "            \"content\": json.dumps(result),\n",
+    "            \"tool_call_id\": tool_call.id,\n",
+    "        })\n",
+    "    return results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "artbec6bf6a",
+   "metadata": {},
+   "source": "## Step 3: Chat function with tool calling\n\nDefines `conversation_history` and `chat()`, which appends the user message, calls the model with `tools` enabled, handles any tool calls by extending the message list with their results, then returns the final assistant reply."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "art3da47ab6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conversation_history = []\n",
+    "\n",
+    "def chat(user_message):\n",
+    "    conversation_history.append({\"role\": \"user\", \"content\": user_message})\n",
+    "    messages = [{\"role\": \"system\", \"content\": system_prompt}] + conversation_history\n",
+    "    response = openai.chat.completions.create(model=MODEL, messages=messages, tools=tools)\n",
+    "\n",
+    "    if response.choices[0].finish_reason == \"tool_calls\":\n",
+    "        message = response.choices[0].message\n",
+    "        tool_responses = handle_tool_call(message)\n",
+    "        messages.append(message)\n",
+    "        messages.extend(tool_responses)\n",
+    "        response = openai.chat.completions.create(model=MODEL, messages=messages)\n",
+    "\n",
+    "    reply = response.choices[0].message.content\n",
+    "    conversation_history.append({\"role\": \"assistant\", \"content\": reply})\n",
+    "    return reply"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "arta4b1a9d4",
+   "metadata": {},
+   "source": "## Step 4: Run the tracker\n\nDefines `run_tracker()`, which displays a welcome message and loops over user input — calling `chat()` and rendering each reply as Markdown — until the user types \"quit\"."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "art320e1729",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "\n",
+       "# Accessibility Repo Tracker\n",
+       "Ask about open issues or the latest release for axe-core, eslint-plugin-jsx-a11y, or NVDA.\n",
+       "Type 'quit' to end the session.\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "---"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "Here's a summary of the open issues in **eslint-plugin-jsx-a11y** related to ARIA attributes:\n",
+       "\n",
+       "---\n",
+       "\n",
+       "### 🏷️ Labeled Issues\n",
+       "\n",
+       "**`new-rule` / `question`**\n",
+       "- **[#986 — Rule Idea: Enforce boolean literals for \"booleanish\" HTML attributes such as `aria-hidden`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/986)**\n",
+       "  *(Opened: May 2024)*\n",
+       "  Proposes a new rule to enforce that booleanish ARIA attributes (like `aria-hidden`) use actual boolean literals (`true`/`false`) instead of string equivalents (`\"true\"`/`\"false\"`).\n",
+       "\n",
+       "---\n",
+       "\n",
+       "### 🔓 Unlabeled Issues\n",
+       "\n",
+       "- **[#839 — Custom ARIA property support](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/839)**\n",
+       "  *(Opened: March 2022)*\n",
+       "  Requests support for custom/non-standard ARIA properties (e.g., `aria-*` attributes not in the ARIA spec) without triggering false positives.\n",
+       "\n",
+       "- **[#910 — `role-supports-aria-props` is not flagging prohibited accessible name usage on generic elements](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/910)**\n",
+       "  *(Opened: December 2022)*\n",
+       "  Reports a bug where the `role-supports-aria-props` rule fails to flag disallowed ARIA properties used on generic/non-semantic elements.\n",
+       "\n",
+       "- **[#946 — `jsx-a11y/iframe-has-title`: title should not be required for hidden frames](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/946)**\n",
+       "  *(Opened: July 2023)*\n",
+       "  Suggests that `<iframe>` elements hidden via `aria-hidden` or similar should be exempt from the `iframe-has-title` rule.\n",
+       "\n",
+       "---\n",
+       "\n",
+       "### 💡 Key Takeaways\n",
+       "- There's an ongoing ask for **custom ARIA attribute support** (longstanding since 2022).\n",
+       "- A **bug exists** in `role-supports-aria-props` around generic elements.\n",
+       "- A **new rule proposal** for stricter boolean ARIA attribute enforcement is under discussion.\n",
+       "\n",
+       "Would you like more details on any of these?"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def run_tracker():\n",
+    "    display(Markdown(\"\"\"\n",
+    "# Accessibility Repo Tracker\n",
+    "Ask about open issues or the latest release for axe-core, eslint-plugin-jsx-a11y, or NVDA.\n",
+    "Type 'quit' to end the session.\n",
+    "\"\"\"))\n",
+    "    while True:\n",
+    "        user_input = input(\"You: \").strip()\n",
+    "        if user_input.lower() == \"quit\":\n",
+    "            break\n",
+    "        if not user_input:\n",
+    "            continue\n",
+    "        reply = chat(user_input)\n",
+    "        display(Markdown(\"---\"))\n",
+    "        display(Markdown(reply))\n",
+    "\n",
+    "run_tracker()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LLM Engineering",
+   "language": "python",
+   "name": "llm-engineering"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
The GitHub API exposes open issues, pull requests, and release notes for any public repository. This notebook wraps it for accessibility-related repos — [axe-core](https://github.com/dequelabs/axe-core), [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), and [NVDA](https://github.com/nvaccess/nvda/) — so you can ask "are there any open axe-core issues related to combobox keyboard handling?" or "what changed in the latest eslint-plugin-jsx-a11y release?" without leaving your workflow. Directly useful for a daily PR-review habit.

## How it works

The model is given two tools:
- `search_repo_issues(repo, query)` — searches open issues/PRs in a repo for a keyword.
- `get_latest_release(repo)` — fetches the latest release notes for a repo.

The model picks the right tool (and `repo`) based on the question, and can call either one — even multiple times in one turn — across a conversation as you ask about different repos.

## Testing Done
- Searched for latest issues in Eslint-plugin-jsx-a11y related to ARIA attributes.
- Obtained details on latest Axe-core release.
- Verified that multi-turn conversation works.
- Entered `quit` and the notebook cell runs and exits the application successfully.
