### PR TITLE
Add the display_open_ai web community contribution

### DIFF
--- a/week1/community-contributions/display_openai_web/scraper_javascript.py
+++ b/week1/community-contributions/display_openai_web/scraper_javascript.py
@@ -1,0 +1,46 @@
+# scraper.py
+import nest_asyncio
+nest_asyncio.apply()
+
+from playwright.sync_api import sync_playwright
+
+def fetch_website_content(url):
+    """
+    Sử dụng Playwright để mở trang web, đợi JavaScript render xong 
+    và lấy toàn bộ text hoặc nội dung HTML của trang.
+    """
+    with sync_playwright() as p:
+        # Khởi chạy trình duyệt ẩn danh (headless=True)
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page(
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
+        )
+        
+        try:
+            print(f"Đang cào dữ liệu từ: {url}...")
+            # Di chuyển đến URL và đợi cho đến khi mạng ổn định (domcontentloaded hoặc networkidle)
+            page.goto(url, wait_until="domcontentloaded")
+            
+            # Đợi thêm một chút nếu trang web load JS quá nặng (tùy chọn)
+            page.wait_for_timeout(2000) 
+            
+            # Cách 1: Lấy text thuần túy đã loại bỏ các thẻ HTML (Khuyên dùng cho AI summarize)
+            content = page.locator("body").inner_text()
+            
+            # Cách 2: Nếu muốn lấy toàn bộ HTML raw thì dùng dòng dưới:
+            # content = page.content()
+            
+            return content
+            
+        except Exception as e:
+            print(f"Có lỗi xảy ra khi cào web: {e}")
+            return ""
+        finally:
+            browser.close()
+
+# Test nhanh file scraper nếu chạy độc lập
+if __name__ == "__main__":
+    test_url = "https://openai.com"
+    result = fetch_website_content(test_url)
+    print("\n--- Kết quả cào thử (500 ký tự đầu tiên) ---")
+    print(result[:500])

--- a/week1/community-contributions/display_openai_web/web_crawler.ipynb
+++ b/week1/community-contributions/display_openai_web/web_crawler.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8f62f67c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from scraper_javascript import fetch_website_content\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f36b304b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2737e857",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "api_key=os.getenv('OPENAI_API_KEY')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44c364e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt=\"\"\"\n",
+    "\"\"\"\n",
+    "user_prompt=\"\"\" \n",
+    "\"\"\"\n",
+    "def messages_for(website):\n",
+    "    return [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt + website}\n",
+    "    ]\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93261d29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def summarize(url):\n",
+    "    website = fetch_website_content(url)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model = \"gpt-4o-mini\",\n",
+    "        messages = messages_for(website)\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "def display_summary(url):\n",
+    "    summary = summarize(url)\n",
+    "    display(Markdown(summary))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13832253",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display_summary(\"https://openai.com\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This community contribution adds a small tool that scrapes JavaScript-rendered web pages using Playwright and summarizes their content via the OpenAI API.
▎ - scraper_javascript.py — scrapes web pages (including dynamic/JS-rendered content) using Playwright
▎ - Summarization logic that sends the scraped content to the OpenAI API and displays a concise summary
▎ Built as part of the Week 1 exercises, extending the day 1 website-summarizer idea to handle JavaScript-heavy sites that requests/BeautifulSoup can't scrape.