### PR TITLE
Add global market news summarizer

### DIFF
--- a/community-contributions/global-market-news-summarizer/assignment-day1.ipynb
+++ b/community-contributions/global-market-news-summarizer/assignment-day1.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b60f36f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Global Market News Summarizer\n",
+    "\n",
+    "Scrapes the latest global market news headlines from Yahoo Finance, extracts the full article content, and uses an LLM (via OpenRouter) to generate a concise, objective daily market briefing — covering overall sentiment, sectors in motion, and key investor takeaways.\n",
+    "\n",
+    "**Built as a community contribution based on Day 1 of Ed Donner's LLM Engineering course.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ebf514a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import necessary libraries\n",
+    "\n",
+    "import os\n",
+    "import requests\n",
+    "import time\n",
+    "from bs4 import BeautifulSoup\n",
+    "from dotenv import load_dotenv\n",
+    "from scraper import fetch_website_contents\n",
+    "from IPython.display import Markdown,display\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2386bc1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv('OPENROUTER_API_KEY')\n",
+    "\n",
+    "if not api_key:\n",
+    "    print(\"No API key was found - please head over to the troubleshooting notebook in this folder to identify & fix!\")\n",
+    "elif not api_key.startswith(\"sk-or-\"):\n",
+    "    print(\"An API key was found, but it doesn't start sk-proj-; please check you're using the right key - see troubleshooting notebook\")\n",
+    "elif api_key.strip() != api_key:\n",
+    "    print(\"An API key was found, but it looks like it might have space or tab characters at the start or end - please remove them - see troubleshooting notebook\")\n",
+    "else:\n",
+    "    print(\"API key found and looks good so far!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90f93073",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = OpenAI(\n",
+    "    base_url=\"https://openrouter.ai/api/v1\",\n",
+    "    api_key=api_key\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2488803f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "headers = {'User-Agent' : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36'}\n",
+    "\n",
+    "def fetch_website_contents(url):\n",
+    "        response = requests.get(url, headers=headers)\n",
+    "        soup = BeautifulSoup(response.content, \"html.parser\")\n",
+    "        title = soup.title.string if soup.title else \"No title found\"\n",
+    "        if soup.body:\n",
+    "            for irrelevant in soup.body([\"script\", \"style\", \"img\", \"input\"]):\n",
+    "                irrelevant.decompose()\n",
+    "            paragraphs = soup.body.find_all(\"p\")\n",
+    "            text = \"\"\n",
+    "            for p in paragraphs:\n",
+    "                text += p.get_text() + \"\\n\"\n",
+    "        else:\n",
+    "            text = \"\"\n",
+    "        return (title + \"\\n\\n\" + text)[:2_000]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d91bacdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fetch_website_links(url):\n",
+    "        response = requests.get(url, headers=headers)\n",
+    "        soup = BeautifulSoup(response.content, \"html.parser\")\n",
+    "        all_tags = soup.find_all(\"a\")\n",
+    "        links = []\n",
+    "        for link in all_tags:\n",
+    "            href = link.get(\"href\")\n",
+    "            if href:\n",
+    "                links.append(href)\n",
+    "        return links"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8bdda10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_links = fetch_website_links(\"https://finance.yahoo.com/news/\")\n",
+    "print(raw_links)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0babc049",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "article_links_raw = []\n",
+    "\n",
+    "for link in raw_links:\n",
+    "    if \"articles\" in link and link.endswith(\".html\"):\n",
+    "        article_links_raw.append(link)\n",
+    "\n",
+    "print(len(article_links_raw))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1acb3ee1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "article_links = []\n",
+    "\n",
+    "for link in article_links_raw:\n",
+    "    if link not in article_links:\n",
+    "        article_links.append(link)\n",
+    "\n",
+    "print(article_links)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fd7f47e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_links = article_links[:5]\n",
+    "\n",
+    "all_articles_content = []\n",
+    "\n",
+    "for link in selected_links:\n",
+    "        content = fetch_website_contents(link)\n",
+    "        all_articles_content.append(content)\n",
+    "        time.sleep(1)\n",
+    "\n",
+    "print(len(all_articles_content))\n",
+    "print(all_articles_content[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7af5138f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "merge_articles = \"\\n\\n---\\n\\n\".join(all_articles_content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a160668d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are a professional market analyst who writes concise, objective daily market wrap-ups.\n",
+    "You will be given the combined content of several news articles about global financial markets.\n",
+    "Summarize them into a clear market briefing.\n",
+    "Do not use humor, sarcasm, or casual language — keep the tone objective and professional, like a Bloomberg or Reuters market wrap.\n",
+    "Respond in markdown. Do not wrap the markdown in a code block.\n",
+    "\"\"\"\n",
+    "\n",
+    "user_prompt = f\"\"\"\n",
+    "Here is the combined content of several recent global market news articles:\n",
+    "\n",
+    "{merge_articles}\n",
+    "\n",
+    "Based on these articles, write a market briefing that includes:\n",
+    "1. Overall market sentiment today (bullish/bearish/mixed), with reasoning\n",
+    "2. Sectors or companies that are moving significantly, and why\n",
+    "3. 2-3 key takeaways an investor should know today\n",
+    "\n",
+    "Keep it concise and skip anything unrelated to markets (ads, navigation text, unrelated topics).\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "88beee60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": system_prompt},\n",
+    "    {\"role\": \"user\", \"content\": user_prompt}\n",
+    "]\n",
+    "\n",
+    "response = client.chat.completions.create(\n",
+    "    model=\"gpt-4o-mini\",\n",
+    "    messages=messages\n",
+    ")\n",
+    "\n",
+    "response = response.choices[0].message.content\n",
+    "\n",
+    "display(Markdown(response))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a28488a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Scrapes global market news headlines from Yahoo Finance, extracts article content, and uses an LLM via OpenRouter to generate a concise daily market briefing (sentiment, sectors in motion, key takeaways).