### PR TITLE
Add Yahoo Finance top losers summarizer

### DIFF
--- a/week1/community-contributions/rundibasci/scraper.py
+++ b/week1/community-contributions/rundibasci/scraper.py
@@ -1,0 +1,76 @@
+from bs4 import BeautifulSoup
+import requests
+from urllib.parse import urljoin, urlparse
+
+
+# Standard headers to fetch a website
+headers = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
+}
+
+
+def fetch_website_contents(url):
+    """
+    Return the title and contents of the website at the given url;
+    truncate to 2,000 characters as a sensible limit
+    """
+    response = requests.get(url, headers=headers)
+    soup = BeautifulSoup(response.content, "html.parser")
+    title = soup.title.string if soup.title else "No title found"
+    if soup.body:
+        for irrelevant in soup.body(["script", "style", "img", "input"]):
+            irrelevant.decompose()
+        text = soup.body.get_text(separator="\n", strip=True)
+    else:
+        text = ""
+    return (title + "\n\n" + text)[:2_000]
+
+
+def fetch_website_links(url):
+    """
+    Return the links on the webiste at the given url
+    I realize this is inefficient as we're parsing twice! This is to keep the code in the lab simple.
+    Feel free to use a class and optimize it!
+    """
+    response = requests.get(url, headers=headers)
+    soup = BeautifulSoup(response.content, "html.parser")
+    links = [link.get("href") for link in soup.find_all("a")]
+    return [link for link in links if link]
+
+
+def fetch_yahoo_top_losers(base_url="https://finance.yahoo.com/", limit=5):
+    """
+    Return the first `limit` tickers from Yahoo Finance's Top Losers table.
+
+    Each result is a dictionary containing the ticker and its absolute quote URL.
+    """
+    losers_url = urljoin(base_url, "markets/stocks/losers/")
+    response = requests.get(losers_url, headers=headers, timeout=20)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    losers = []
+    seen_tickers = set()
+    for row in soup.select("table tbody tr"):
+        quote_link = row.select_one('a[href*="/quote/"]')
+        if not quote_link:
+            continue
+
+        quote_url = urljoin(base_url, quote_link.get("href"))
+        path_parts = urlparse(quote_url).path.strip("/").split("/")
+        if len(path_parts) < 2 or path_parts[0] != "quote":
+            continue
+
+        ticker = path_parts[1].upper()
+        if ticker in seen_tickers:
+            continue
+
+        losers.append({"ticker": ticker, "url": quote_url})
+        seen_tickers.add(ticker)
+        if len(losers) == limit:
+            break
+
+    if not losers:
+        raise ValueError("Non è stato possibile trovare i ticker nella sezione Top Losers")
+
+    return losers

--- a/week1/community-contributions/rundibasci/yahooFinanceTimeForLosers.ipynb
+++ b/week1/community-contributions/rundibasci/yahooFinanceTimeForLosers.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-environment",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explain-environment",
+   "metadata": {},
+   "source": [
+    "The environment variables are now loaded from the local `.env` file. This makes the OpenAI API key available without storing it directly in the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "create-openai-client",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explain-openai-client",
+   "metadata": {},
+   "source": [
+    "The OpenAI client will be used to generate a concise summary for each stock. Next, we define the Yahoo Finance starting page and the maximum number of losing stocks to analyze."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "request-and-validate-url",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "website_url = \"https://finance.yahoo.com/\"\n",
+    "top_losers_limit = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explain-configuration",
+   "metadata": {},
+   "source": [
+    "These settings keep the data source and result limit easy to change. The following cell loads the scraping helpers and defines how the content of each ticker page is summarized."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "summarize-website",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import importlib\n",
+    "import scraper\n",
+    "\n",
+    "importlib.reload(scraper)\n",
+    "from scraper import fetch_website_contents, fetch_yahoo_top_losers\n",
+    "\n",
+    "\n",
+    "def summarize(ticker: str, ticker_url: str) -> str:\n",
+    "    \"\"\"Analizza la pagina Yahoo Finance di un ticker e restituisce una breve sintesi.\"\"\"\n",
+    "    ticker_contents = fetch_website_contents(ticker_url)\n",
+    "    if not ticker_contents.strip():\n",
+    "        raise ValueError(f\"La pagina di {ticker} non contiene testo analizzabile\")\n",
+    "\n",
+    "    completion = openai.chat.completions.create(\n",
+    "        model=\"gpt-4.1-nano\",\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"system\",\n",
+    "                \"content\": (\n",
+    "                    \"Sei un analista finanziario sintetico e prudente. Riassumi in italiano i dati presenti \"\n",
+    "                    \"nella pagina Yahoo Finance del titolo, spiegando società, andamento mostrato e possibili \"\n",
+    "                    \"elementi rilevanti. Non inventare dati e non fornire raccomandazioni di investimento. \"\n",
+    "                    \"Produci un unico breve paragrafo, senza titolo e senza tabella.\"\n",
+    "                ),\n",
+    "            },\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": f\"Ticker: {ticker}\\nURL: {ticker_url}\\n\\nContenuto della pagina:\\n{ticker_contents}\",\n",
+    "            },\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "    return completion.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "explain-summarization",
+   "metadata": {},
+   "source": [
+    "The `summarize` function extracts readable page content and asks the model for a cautious summary in Italian. The final cell retrieves the top losers, summarizes them one at a time, and presents the results in a Markdown table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run-website-summary",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "top_losers = fetch_yahoo_top_losers(website_url, limit=top_losers_limit)\n",
+    "summaries = []\n",
+    "\n",
+    "for item in top_losers:\n",
+    "    ticker_summary = summarize(item[\"ticker\"], item[\"url\"])\n",
+    "    summaries.append({**item, \"summary\": ticker_summary})\n",
+    "\n",
+    "markdown_rows = [\n",
+    "    \"# Yahoo Finance — Top Losers\",\n",
+    "    \"\",\n",
+    "    \"| Ticker | Sintesi |\",\n",
+    "    \"|---|---|\",\n",
+    "]\n",
+    "for item in summaries:\n",
+    "    clean_summary = item[\"summary\"].replace(\"\\n\", \" \").replace(\"|\", \"\\\\|\")\n",
+    "    markdown_rows.append(f'| [{item[\"ticker\"]}]({item[\"url\"]}) | {clean_summary} |')\n",
+    "\n",
+    "final_report = \"\\n\".join(markdown_rows)\n",
+    "display(Markdown(final_report))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What changed

- Added a Yahoo Finance scraper that retrieves the top losing stock tickers and their quote URLs.
- Added a notebook that summarizes each ticker with OpenAI and presents the results in a Markdown table.
- Added short English explanations between notebook code cells.

## Why

This contribution demonstrates how to combine web scraping and an LLM to produce a concise, cautious overview of Yahoo Finance's top losing stocks.

## Validation

- Confirmed that the notebook contains no saved outputs.
- Confirmed that the staged Python files compile successfully.
- Confirmed that the PR contains only the two files under `week1/community-contributions/rundibasci`.
