### PR TITLE
Add email subject line generator - Week 1 Day 1 exercise

### DIFF
--- a/week1/community-contributions/day1_email_subject_generator_kdemon.ipynb
+++ b/week1/community-contributions/day1_email_subject_generator_kdemon.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Email Subject Line Generator\n",
+    "\n",
+    "A simple commercial use case: given the body of an email, suggest a concise, professional subject line.\n",
+    "\n",
+    "This is the kind of feature that could be built into a commercial email tool like Gmail or Outlook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"You are an expert email assistant. Given the body of an email,\n",
+    "suggest a concise, professional subject line that captures the key point.\n",
+    "Respond with only the subject line, nothing else.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def suggest_subject(email_body):\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": email_body}\n",
+    "    ]\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model=\"gpt-4.1-nano\",\n",
+    "        messages=messages\n",
+    "    )\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "source": [
+    "## Example 1: Budget reallocation email"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email_1 = \"\"\"\n",
+    "Dear Team,\n",
+    "\n",
+    "I wanted to follow up on our discussion from last Friday's meeting regarding the Q3 budget allocation.\n",
+    "After reviewing the numbers with the finance department, we've identified an opportunity to reallocate\n",
+    "approximately $50,000 from the marketing budget to the R&D department. This would allow us to accelerate\n",
+    "the development timeline for the new product launch by roughly two weeks.\n",
+    "\n",
+    "Could we schedule a brief call this week to discuss the implications and get everyone's approval?\n",
+    "I'm available Tuesday afternoon or Wednesday morning.\n",
+    "\n",
+    "Best regards,\n",
+    "Sarah\n",
+    "\"\"\"\n",
+    "\n",
+    "subject = suggest_subject(email_1)\n",
+    "print(f\"Suggested subject: {subject}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "source": [
+    "## Example 2: Meeting reschedule email"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email_2 = \"\"\"\n",
+    "Hi Mark,\n",
+    "\n",
+    "Unfortunately, I need to reschedule our Thursday product demo. The client just informed us that\n",
+    "their CTO won't be available until next week. I've checked with the team and we can do either\n",
+    "Monday at 2pm or Tuesday at 10am next week.\n",
+    "\n",
+    "Please let me know which works better for your side, and I'll confirm with the client.\n",
+    "\n",
+    "Thanks,\n",
+    "Priya\n",
+    "\"\"\"\n",
+    "\n",
+    "subject = suggest_subject(email_2)\n",
+    "print(f\"Suggested subject: {subject}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "## Example 3: Project status update"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email_3 = \"\"\"\n",
+    "Hello everyone,\n",
+    "\n",
+    "Quick update on Project Phoenix: we've completed the database migration ahead of schedule.\n",
+    "All 2.3 million records have been transferred and validated. Performance tests show a 40%\n",
+    "improvement in query response times compared to the old system.\n",
+    "\n",
+    "Next steps: we'll begin the API integration phase starting Monday. I'll send a detailed\n",
+    "timeline by end of day Friday.\n",
+    "\n",
+    "Cheers,\n",
+    "Alex\n",
+    "\"\"\"\n",
+    "\n",
+    "subject = suggest_subject(email_3)\n",
+    "print(f\"Suggested subject: {subject}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "## Batch mode: process multiple emails at once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "emails = [email_1, email_2, email_3]\n",
+    "\n",
+    "for i, email in enumerate(emails, 1):\n",
+    "    subject = suggest_subject(email)\n",
+    "    print(f\"Email {i} -> {subject}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Week 1 Day 1 community contribution: an Email Subject Line Generator.

A practical commercial use case that takes the body of an email and suggests a concise, professional subject line using GPT-4.1-nano.

Includes:
- A reusable suggest_subject() function
- 3 diverse email examples (budget reallocation, meeting reschedule, project status update)
- A batch processing demo

Checklist:
- [x] Only changes in community-contributions
- [x] All notebook outputs cleared
- [x] Under 2,000 lines (205 lines)
- [x] No unnecessary files, README, .env.example, or LLM artifacts