### PR TITLE
Fix Course Navigator crash on Python 3.11

### DIFF
--- a/community-contributions/Nishant-444/course_navigator/app.py
+++ b/community-contributions/Nishant-444/course_navigator/app.py
@@ -142,7 +142,10 @@ def explore_search(query, top_k):
             if file_type == "python" or (file_type == "notebook" and meta.get("cell_type") == "code"):
                 md_output += f"```python\n{content}\n```\n\n"
             else:
-                md_output += f"> {content.replace('\n', '\n> ')}\n\n"
+                # Build the blockquote separately: a backslash inside an f-string
+                # expression is only legal on Python 3.12+, and this repo supports 3.11.
+                quoted = content.replace("\n", "\n> ")
+                md_output += f"> {quoted}\n\n"
             md_output += "---\n\n"
             
         return md_output


### PR DESCRIPTION
app.py used a backslash inside an f-string expression, which is only valid from Python 3.12 (PEP 701). pyproject.toml declares requires-python = >=3.11, so students on 3.11 hit a SyntaxError at import and the app never starts.

Build the blockquote string before interpolating it instead.