### PR TITLE
Add MedPlain medical jargon translator

### DIFF
--- a/week1/community-contributions/Yesh_Damania/medplain_medical_jargon_translator.ipynb
+++ b/week1/community-contributions/Yesh_Damania/medplain_medical_jargon_translator.ipynb
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "95e6ea90",
    "metadata": {},
    "outputs": [],
@@ -99,18 +99,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "feb5e196",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "API key found!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Load environment variables from the .env file\n",
     "load_dotenv(override=True)\n",
@@ -173,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "cfc98635",
    "metadata": {},
    "outputs": [],
@@ -216,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "id": "3eaad98c",
    "metadata": {},
    "outputs": [],
@@ -268,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "id": "086c1b8c",
    "metadata": {},
    "outputs": [],
@@ -300,7 +292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "a1d9874e",
    "metadata": {},
    "outputs": [],
@@ -334,35 +326,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "d94413ef",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/markdown": [
-       "## Simple Explanation\n",
-       "Hypertension means high blood pressure. Blood pressure is the push of blood through your arteries as your heart beats. If this push stays higher than normal, it’s called hypertension (high blood pressure). A single high reading isn’t enough to say you have it— doctors look at several readings over time.\n",
-       "\n",
-       "## General Meaning\n",
-       "This term appears in a medical report when the doctor found that your blood pressure readings are higher than normal. It tells the doctor and you that careful checking and perhaps follow-up tests may be needed to understand what is happening and how to monitor it.\n",
-       "\n",
-       "## Questions to Ask a Doctor\n",
-       "1) What do these blood pressure numbers mean for my health?  \n",
-       "2) Should I have more readings or tests to check my blood pressure?  \n",
-       "3) Are there simple steps I can take to keep my blood pressure in a healthy range?\n",
-       "\n",
-       "## Important Note\n",
-       "This is general information, not medical advice."
-      ],
-      "text/plain": [
-       "<IPython.core.display.Markdown object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Display the MedPlain response\n",
     "\n",

--- a/week1/community-contributions/Yesh_Damania/medplain_medical_jargon_translator.ipynb
+++ b/week1/community-contributions/Yesh_Damania/medplain_medical_jargon_translator.ipynb
@@ -1,0 +1,413 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6d41bc78",
+   "metadata": {},
+   "source": [
+    "# MedPlain — Medical Jargon Translator\n",
+    "\n",
+    "MedPlain is a simple healthcare-focused LLM project.\n",
+    "\n",
+    "A user enters a difficult medical word from a report, such as:\n",
+    "\n",
+    "- Hypertension\n",
+    "- Inflammation\n",
+    "- Benign\n",
+    "- Anemia\n",
+    "\n",
+    "MedPlain explains the word in simple English or Hinglish.\n",
+    "\n",
+    "> Important: MedPlain does not diagnose diseases, recommend medicines. It only explains medical words in a simple way."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dd0cd88",
+   "metadata": {},
+   "source": [
+    "## Problem Statement\n",
+    "\n",
+    "Medical reports often contain difficult words that people may not understand.\n",
+    "\n",
+    "For example, someone may see words like \"hypertension\" or \"benign\" in a report and feel confused or worried.\n",
+    "\n",
+    "The goal of MedPlain is to make these words easier to understand.\n",
+    "\n",
+    "MedPlain will:\n",
+    "1. Explain the medical term in simple language\n",
+    "2. Give general meaning of the term\n",
+    "3. Suggest simple questions the user can ask a doctor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bb370b2",
+   "metadata": {},
+   "source": [
+    "<div align=\"center\">\n",
+    "    <img src=\"How_it_Works.png\" alt=\"How MedPlain Works\" width=\"500\">\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17605dc8",
+   "metadata": {},
+   "source": [
+    "## Import the Required Libraries\n",
+    "\n",
+    "First, I import the libraries needed for this project.\n",
+    "\n",
+    "The `OpenAI` library allows MedPlain to communicate with the OpenAI model.\n",
+    "\n",
+    "The `dotenv` library loads the OpenAI API key from the `.env` file.\n",
+    "\n",
+    "The `Markdown` and `display` functions display the final response with proper Markdown formatting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "95e6ea90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6055acdb",
+   "metadata": {},
+   "source": [
+    "## Load the OpenAI API Key\n",
+    "\n",
+    "The OpenAI API key should not be written directly inside the notebook.\n",
+    "\n",
+    "Instead, the API key should be stored inside a local `.env` file.\n",
+    "\n",
+    "The `.env` file should contain:\n",
+    "\n",
+    "`OPENAI_API_KEY=your_openai_api_key_here`\n",
+    "\n",
+    "The `.env` file should never be uploaded to GitHub because it contains private information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "feb5e196",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "API key found!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load environment variables from the .env file\n",
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv(\"OPENAI_API_KEY\")\n",
+    "\n",
+    "# Check the key\n",
+    "\n",
+    "if not api_key:\n",
+    "    print(\"No API key was found. Please add OPENAI_API_KEY to your .env file.\")\n",
+    "else:\n",
+    "    print(\"API key found!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60b8865a",
+   "metadata": {},
+   "source": [
+    "## Step 1: Choose a Medical Term\n",
+    "\n",
+    "First, I choose the medical term that I want MedPlain to explain.\n",
+    "\n",
+    "I can also add a short sentence from a report for context.\n",
+    "\n",
+    "**I haven't included Patient's private information such as Name, Address, DOB, Hospital ID.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01382f6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# choose the medical term, context & language\n",
+    "medical_term = \"hypertension\"\n",
+    "\n",
+    "report_context = \"This word appeared in medical report\"\n",
+    "\n",
+    "language = \"English\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4390bbca",
+   "metadata": {},
+   "source": [
+    "## Step 2: Create the System Prompt\n",
+    "\n",
+    "A system prompt tells the AI what role it should play.\n",
+    "\n",
+    "In this project, the system prompt tells the AI:\n",
+    "\n",
+    "- It is MedPlain, a medical jargon translator\n",
+    "- It should use simple language\n",
+    "- It should not diagnose diseases\n",
+    "- It should not give medicine or treatment advice\n",
+    "- It should give general information only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "cfc98635",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the system prompt\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "You are MedPlain, a medical jargon translator.\n",
+    "\n",
+    "Your job is to explain medical terms in very simple language.\n",
+    "\n",
+    "Rules:\n",
+    "- Do not diagnose any disease.\n",
+    "- Do not give treatment, medicine, or dosage advice.\n",
+    "- Do not assume anything about the user's health.\n",
+    "- Explain the medical term only in a general way.\n",
+    "- Use simple and clear language.\n",
+    "- If the user chooses Hinglish, use easy Hindi written in English letters mixed with simple English.\n",
+    "- Do not use difficult medical words unless you explain them.\n",
+    "- Use clear Markdown headings.\n",
+    "- End with: \"This is general information, not medical advice.\"\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0347f6a6",
+   "metadata": {},
+   "source": [
+    "## Step 3: Create the User Prompt\n",
+    "\n",
+    "A user prompt contains the actual request sent to the AI.\n",
+    "\n",
+    "Here, the user prompt includes:\n",
+    "- The medical term\n",
+    "- The optional report context\n",
+    "- The preferred language: English or Hinglish\n",
+    "- The format that MedPlain should use for its answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "3eaad98c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the user prompt\n",
+    "\n",
+    "user_prompt = f\"\"\"\n",
+    "Please explain this medical term.\n",
+    "\n",
+    "Medical term: {medical_term}\n",
+    "\n",
+    "Context from report:\n",
+    "{report_context}\n",
+    "\n",
+    "Preferred explanation style: {language}\n",
+    "\n",
+    "Use exactly this format:\n",
+    "\n",
+    "## Simple Explanation\n",
+    "Explain the term in easy language.\n",
+    "\n",
+    "## General Meaning\n",
+    "Explain why this term may appear in a medical report.\n",
+    "\n",
+    "## Questions to Ask a Doctor\n",
+    "Give 3 simple questions the user can ask their doctor.\n",
+    "\n",
+    "## Important Note\n",
+    "Write: This is general information, not medical advice.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68e1bc99",
+   "metadata": {},
+   "source": [
+    "## Step 4: Create the Messages List\n",
+    "\n",
+    "OpenAI expects prompts in a list called `messages`.\n",
+    "\n",
+    "Each message has a role:\n",
+    "\n",
+    "- `system` tells the AI its job and rules\n",
+    "- `user` gives the AI the actual request\n",
+    "\n",
+    "The messages list combines both prompts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "086c1b8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make the messages list\n",
+    "\n",
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": system_prompt},\n",
+    "    {\"role\": \"user\", \"content\": user_prompt}\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94a0ad99",
+   "metadata": {},
+   "source": [
+    "## Step 5: Call OpenAI\n",
+    "\n",
+    "Now I send the messages to the OpenAI model.\n",
+    "\n",
+    "The model reads:\n",
+    "1. The system prompt\n",
+    "2. The user prompt\n",
+    "3. The requested output format\n",
+    "\n",
+    "Then it creates a simple explanation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "a1d9874e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call OpenAI\n",
+    "openai = OpenAI()\n",
+    "\n",
+    "response = openai.chat.completions.create(\n",
+    "    model=\"gpt-5-nano\",\n",
+    "    messages=messages\n",
+    ")\n",
+    "\n",
+    "responses = response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6228199d",
+   "metadata": {},
+   "source": [
+    "## Step 6: Display the Response\n",
+    "\n",
+    "The OpenAI response contains the explanation generated by MedPlain.\n",
+    "\n",
+    "The answer is available inside:\n",
+    "\n",
+    "`response.choices[0].message.content`\n",
+    "\n",
+    "I use `display` and `Markdown` to show the response with properly formatted headings and lists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "d94413ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "## Simple Explanation\n",
+       "Hypertension means high blood pressure. Blood pressure is the push of blood through your arteries as your heart beats. If this push stays higher than normal, it’s called hypertension (high blood pressure). A single high reading isn’t enough to say you have it— doctors look at several readings over time.\n",
+       "\n",
+       "## General Meaning\n",
+       "This term appears in a medical report when the doctor found that your blood pressure readings are higher than normal. It tells the doctor and you that careful checking and perhaps follow-up tests may be needed to understand what is happening and how to monitor it.\n",
+       "\n",
+       "## Questions to Ask a Doctor\n",
+       "1) What do these blood pressure numbers mean for my health?  \n",
+       "2) Should I have more readings or tests to check my blood pressure?  \n",
+       "3) Are there simple steps I can take to keep my blood pressure in a healthy range?\n",
+       "\n",
+       "## Important Note\n",
+       "This is general information, not medical advice."
+      ],
+      "text/plain": [
+       "<IPython.core.display.Markdown object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Display the MedPlain response\n",
+    "\n",
+    "display(Markdown(response.choices[0].message.content))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc093524",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "MedPlain demonstrates how an OpenAI model can explain difficult medical words using simple English or Hinglish.\n",
+    "\n",
+    "The project uses:\n",
+    "\n",
+    "- A system prompt to define the role and safety rules\n",
+    "- A user prompt to provide the medical term and context\n",
+    "- A messages list to send both prompts to OpenAI\n",
+    "- The OpenAI response to display the final explanation\n",
+    "\n",
+    "MedPlain provides general educational information only and does not provide medical advice."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description

This contribution adds MedPlain, a Week 1 healthcare-focused LLM project that explains difficult medical terminology in simple English or Hinglish.

## What the notebook demonstrates

- System and user prompt design
- OpenAI chat completions
- Markdown-formatted responses
- English and Hinglish explanations
- Basic healthcare safety guardrails

## Safety scope

MedPlain provides general educational explanations only. It does not diagnose diseases, recommend medicine, provide treatment advice, or interpret individual medical reports.

## Files added

- `medplain_medical_jargon_translator.ipynb`
- `How_it_Works.png`