### PR TITLE
Add three-way GPT/Claude/Ollama chatbot for week2 day1 exercise

### DIFF
--- a/community-contributions/CodeMaestroMS/three-way-chatbot-gpt-claude-ollama.ipynb
+++ b/community-contributions/CodeMaestroMS/three-way-chatbot-gpt-claude-ollama.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbec7620",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "from IPython.display import Markdown, display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2a0d096",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "\n",
+    "anthropic_api_key = os.getenv(\"ANTHROPIC_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b8c7294",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openai = OpenAI()\n",
+    "anthropic = OpenAI(api_key=anthropic_api_key, base_url=\"https://api.anthropic.com/v1/\")\n",
+    "ollama = OpenAI(base_url=\"http://localhost:11434/v1\", api_key=\"ollama\")\n",
+    "\n",
+    "GPT_MODEL = \"gpt-4.1-mini\"\n",
+    "CLAUDE_MODEL = \"claude-haiku-4-5\"\n",
+    "OLLAMA_MODEL = \"llama3.2\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "340a4b81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Three local fishermen down at a UK harbour. Alex and Charlie argue with each other;\n",
+    "# Blake tries to keep the peace between them.\n",
+    "\n",
+    "alex_system_prompt = \"\"\"\n",
+    "You are Alex, a fisherman from a small harbour town on the UK coast. You've been hauling pots and nets for thirty years and reckon you know best about everything - the weather, the tides, the going rate for the day's catch. You're argumentative and snarky, always ready to disagree with whatever the other two say, in a blunt, down-to-earth way, with the odd bit of local fishing chat thrown in. Keep your replies short and natural, like real quayside talk.\n",
+    "You are in a conversation with Blake and Charlie, fellow fishermen down at the harbour.\n",
+    "\"\"\"\n",
+    "\n",
+    "charlie_system_prompt = \"\"\"\n",
+    "You are Charlie, a stubborn old fisherman from the same UK harbour. You've fished these waters your whole life and don't take kindly to being told you're wrong. You argue back at whatever Alex says and refuse to back down, in a blunt, combative way, with talk of nets, tides, and the day's catch. Keep your replies short and natural, like real quayside talk.\n",
+    "You are in a conversation with Alex and Blake, fellow fishermen down at the harbour.\n",
+    "\"\"\"\n",
+    "\n",
+    "blake_system_prompt = \"\"\"\n",
+    "You are Blake, a good-natured fisherman from the same UK harbour as Alex and Charlie. You're the calm one of the three - always trying to smooth things over, find common ground, and keep the peace when Alex and Charlie start bickering, usually over a cup of tea on the quayside. Keep your replies short and natural, like real quayside talk.\n",
+    "You are in a conversation with Alex and Charlie, fellow fishermen down at the harbour.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "242c8c74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PARTICIPANTS = {\n",
+    "    \"Alex\": {\n",
+    "        \"client\": openai,\n",
+    "        \"model\": GPT_MODEL,\n",
+    "        \"system_prompt\": alex_system_prompt,\n",
+    "        \"others\": \"Blake and Charlie\",\n",
+    "    },\n",
+    "    \"Charlie\": {\n",
+    "        \"client\": ollama,\n",
+    "        \"model\": OLLAMA_MODEL,\n",
+    "        \"system_prompt\": charlie_system_prompt,\n",
+    "        \"others\": \"Alex and Blake\",\n",
+    "    },\n",
+    "    \"Blake\": {\n",
+    "        \"client\": anthropic,\n",
+    "        \"model\": CLAUDE_MODEL,\n",
+    "        \"system_prompt\": blake_system_prompt,\n",
+    "        \"others\": \"Alex and Charlie\",\n",
+    "    },\n",
+    "}\n",
+    "\n",
+    "history = []  # list of (name, message) tuples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d75ed7c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def render_conversation() -> str:\n",
+    "    \"\"\"Render the conversation so far as 'Name: message' lines.\"\"\"\n",
+    "    return \"\\n\".join(f\"{name}: {message}\" for name, message in history)\n",
+    "\n",
+    "\n",
+    "def next_message(name: str) -> str:\n",
+    "    \"\"\"Ask the participant `name` for their next line, given the conversation so far.\"\"\"\n",
+    "    participant = PARTICIPANTS[name]\n",
+    "    conversation = render_conversation()\n",
+    "    user_prompt = f\"\"\"\n",
+    "You are {name}, in conversation with {participant['others']}.\n",
+    "The conversation so far is as follows:\n",
+    "{conversation}\n",
+    "Now with this, respond with what you would like to say next, as {name}.\n",
+    "\"\"\"\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": participant[\"system_prompt\"]},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt},\n",
+    "    ]\n",
+    "    response = participant[\"client\"].chat.completions.create(\n",
+    "        model=participant[\"model\"], messages=messages\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "def add_message(name: str, message: str) -> None:\n",
+    "    \"\"\"Append a message to the conversation and display it.\"\"\"\n",
+    "    history.append((name, message))\n",
+    "    display(Markdown(f\"### {name}:\\n{message}\\n\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5ee3588",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "add_message(\"Alex\", \"Mornin'. Nets were empty again out past the point.\")\n",
+    "add_message(\"Charlie\", \"Empty? You were fishing the wrong ground again, weren't you.\")\n",
+    "add_message(\"Blake\", \"Now now, let's not start already, it's barely gone six.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61c00da9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for round_number in range(3):\n",
+    "    for name in PARTICIPANTS:\n",
+    "        add_message(name, next_message(name))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a461f6d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering (3.12.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Week 2, Day 1 "additional exercise" solution: replace one of the two models (GPT/Claude) with an open-source model running locally via Ollama.
- Builds a three-way conversation between GPT-4.1-mini, Claude Haiku 4.5, and a local Ollama model (llama3.2), using the single system-prompt + single user-prompt-with-full-history pattern suggested in the notebook's advanced exercise notes.
- Personas: two fishermen at a UK harbour (GPT, Ollama) bicker over the day's catch and fishing grounds, while the third (Claude) plays peacemaker.