### PR TITLE
Fix Issue#3528: update gemini model version and google api key format check

### DIFF
--- a/guides/09_ai_apis_and_ollama.ipynb
+++ b/guides/09_ai_apis_and_ollama.ipynb
@@ -101,7 +101,7 @@
     "GEMINI_BASE_URL = \"https://generativelanguage.googleapis.com/v1beta/openai/\"\n",
     "google_api_key = os.getenv(\"GOOGLE_API_KEY\")\n",
     "gemini = OpenAI(base_url=GEMINI_BASE_URL, api_key=google_api_key)\n",
-    "response = gemini.chat.completions.create(model=\"gemini-2.5-flash-preview-05-20\", messages=[{\"role\":\"user\", \"content\": \"what is 2+2?\"}])\n",
+    "response = gemini.chat.completions.create(model=\"gemini-3.1-flash-lite\", messages=[{\"role\":\"user\", \"content\": \"what is 2+2?\"}])\n",
     "print(response.choices[0].message.content)\n",
     "```\n",
     "\n",

--- a/week1/day2.ipynb
+++ b/week1/day2.ipynb
@@ -228,7 +228,7 @@
    "source": [
     "gemini = OpenAI(base_url=GEMINI_BASE_URL, api_key=google_api_key)\n",
     "\n",
-    "response = gemini.chat.completions.create(model=\"gemini-2.5-flash-lite\", messages=[{\"role\": \"user\", \"content\": \"Tell me a fun fact\"}])\n",
+    "response = gemini.chat.completions.create(model=\"gemini-3.1-flash-lite\", messages=[{\"role\": \"user\", \"content\": \"Tell me a fun fact\"}])\n",
     "\n",
     "response.choices[0].message.content"
    ]

--- a/week1/day2.ipynb
+++ b/week1/day2.ipynb
@@ -212,8 +212,8 @@
     "\n",
     "if not google_api_key:\n",
     "    print(\"No API key was found - please be sure to add your key to the .env file, and save the file! Or you can skip the next 2 cells if you don't want to use Gemini\")\n",
-    "elif not google_api_key.startswith(\"AIz\"):\n",
-    "    print(\"An API key was found, but it doesn't start AIz\")\n",
+    "elif not google_api_key.startswith((\"AIz\", \"AQ.\")):\n",
+    "    print(\"An API key was found, but it doesn't start with AIz or AQ.\")\n",
     "else:\n",
     "    print(\"API key found and looks good so far!\")\n",
     "\n"

--- a/week2/day1.ipynb
+++ b/week2/day1.ipynb
@@ -534,7 +534,7 @@
     "client = genai.Client()\n",
     "\n",
     "response = client.models.generate_content(\n",
-    "    model=\"gemini-2.5-flash-lite\", contents=\"Describe the color Blue to someone who's never been able to see in 1 sentence\"\n",
+    "    model=\"gemini-3.1-flash-lite\", contents=\"Describe the color Blue to someone who's never been able to see in 1 sentence\"\n",
     ")\n",
     "print(response.text)"
    ]
@@ -679,7 +679,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = completion(model=\"gemini/gemini-2.5-flash-lite\", messages=question)\n",
+    "response = completion(model=\"gemini/gemini-3.1-flash-lite\", messages=question)\n",
     "display(Markdown(response.choices[0].message.content))"
    ]
   },
@@ -713,7 +713,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = completion(model=\"gemini/gemini-2.5-flash-lite\", messages=question)\n",
+    "response = completion(model=\"gemini/gemini-3.1-flash-lite\", messages=question)\n",
     "display(Markdown(response.choices[0].message.content))"
    ]
   },
@@ -737,7 +737,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "response = completion(model=\"gemini/gemini-2.5-flash-lite\", messages=question)\n",
+    "response = completion(model=\"gemini/gemini-3.1-flash-lite\", messages=question)\n",
     "display(Markdown(response.choices[0].message.content))"
    ]
   },

--- a/week4/day3.ipynb
+++ b/week4/day3.ipynb
@@ -140,7 +140,7 @@
     "# OPENAI_MODEL = \"gpt-5-nano\"\n",
     "# CLAUDE_MODEL = \"claude-haiku-4-5\"\n",
     "# GROK_MODEL = \"grok-4-fast-non-reasoning\"\n",
-    "# GEMINI_MODEL = \"gemini-2.5-flash-lite\""
+    "# GEMINI_MODEL = \"gemini-3.1-flash-lite\""
    ]
   },
   {

--- a/week6/day4.ipynb
+++ b/week6/day4.ipynb
@@ -469,7 +469,7 @@
    "outputs": [],
    "source": [
     "def gemini_2__5_flash_lite(item):\n",
-    "    response = completion(model=\"gemini/gemini-2.5-flash-lite\", messages=messages_for(item))\n",
+    "    response = completion(model=\"gemini/gemini-3.1-flash-lite\", messages=messages_for(item))\n",
     "    return response.choices[0].message.content"
    ]
   },


### PR DESCRIPTION
### Summary

- replaces used gemini-2.5-flash-lite model with gemini-3.1-flash-lite in labs and guides (but not community contributions)
- allows google api key to start with "AQ." in string check

Fixes #3528 