### PR TITLE
Added Week 2 exercise of ai tutor with chatbot, model switching optio…

### DIFF
--- a/week2/community-contributions/sheharyaar-week-2-exercises/week2 EXERCISE.ipynb
+++ b/week2/community-contributions/sheharyaar-week-2-exercises/week2 EXERCISE.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d006b2ea-9dfe-49c7-88a9-a5a0775185fd",
+   "metadata": {},
+   "source": [
+    "# Additional End of week Exercise - week 2\n",
+    "\n",
+    "Now use everything you've learned from Week 2 to build a full prototype for the technical question/answerer you built in Week 1 Exercise.\n",
+    "\n",
+    "This should include a Gradio UI, streaming, use of the system prompt to add expertise, and the ability to switch between models. Bonus points if you can demonstrate use of a tool!\n",
+    "\n",
+    "If you feel bold, see if you can add audio input so you can talk to it, and have it respond with audio. ChatGPT or Claude can help you, or email me if you have questions.\n",
+    "\n",
+    "I will publish a full solution here soon - unless someone beats me to it...\n",
+    "\n",
+    "There are so many commercial applications for this, from a language tutor, to a company onboarding solution, to a companion AI to a course (like this one!) I can't wait to see your results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a07e7793-b8f5-44f4-aded-5562f633271a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from openai import OpenAI\n",
+    "from dotenv import load_dotenv\n",
+    "import gradio as gr\n",
+    "import json\n",
+    "from datetime import datetime\n",
+    "\n",
+    "NOTES_DIR = \"notes\"\n",
+    "os.makedirs(NOTES_DIR, exist_ok=True)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d78e249a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "\n",
+    "PROVIDERS = {\n",
+    "    \"Ollama (local)\": {\n",
+    "        \"client\": OpenAI(base_url=os.getenv(\"OLLAMA_BASE_URL\"), api_key=\"ollama\"),\n",
+    "        \"model\": \"llama3.2\",\n",
+    "    },\n",
+    "    \"Groq\": {\n",
+    "        \"client\": OpenAI(base_url=os.getenv(\"GROQ_BASE_URL\"), api_key=os.getenv(\"GROQ_API_KEY\")),\n",
+    "        \"model\": \"llama-3.1-8b-instant\",   # or \"llama-3.3-70b-versatile\"\n",
+    "    },\n",
+    "    \"Gemini\": {\n",
+    "        \"client\": OpenAI(base_url=os.getenv(\"GOOGLE_BASE_URL\"), api_key=os.getenv(\"GOOGLE_API_KEY\")),\n",
+    "        \"model\": \"gemini-3.1-flash-lite\",\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95362e95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXPERTISE_PROMPTS = {\n",
+    "    \"Python Developer\": \"You are a senior Python developer. Explain code line-by-line, covering behavior, purpose, and edge cases.\",\n",
+    "    \"JavaScript Developer\": \"You are a senior JavaScript/frontend developer. Explain code clearly, including async behavior, browser APIs, and gotchas.\",\n",
+    "    \"SQL / Data Engineer\": \"You are a senior data engineer. Explain queries or data code in terms of performance, correctness, and edge cases.\",\n",
+    "    \"Beginner-Friendly Tutor\": \"You are a patient coding tutor explaining to someone new to programming. Avoid jargon, use analogies.\",\n",
+    "    \"System Design / Architecture\": \"You are a staff engineer reviewing code for architecture, scalability, and maintainability concerns.\",\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e7904f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def explain_code_stream(code: str, provider_name: str, expertise: str):\n",
+    "    provider = PROVIDERS[provider_name]\n",
+    "    client = provider[\"client\"]\n",
+    "    model = provider[\"model\"]\n",
+    "\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": EXPERTISE_PROMPTS[expertise]},\n",
+    "        {\"role\": \"user\", \"content\": f\"Explain the following code in detail:\\n\\n{code}\\n\\nInclude how it works and why each part is used.\"},\n",
+    "    ]\n",
+    "\n",
+    "    stream = client.chat.completions.create(\n",
+    "        model=model,\n",
+    "        messages=messages,\n",
+    "        stream=True,\n",
+    "    )\n",
+    "\n",
+    "    partial = \"\"\n",
+    "    for chunk in stream:\n",
+    "        delta = chunk.choices[0].delta.content or \"\"\n",
+    "        partial += delta\n",
+    "        yield partial   # yielding the growing string is what makes Gradio \"type\" it out live"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "665cfcdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def save_full_response(history):\n",
+    "    if not history:\n",
+    "        return None\n",
+    "    last_question, last_answer = history[-1]          # gr.Chatbot stores (user, bot) tuples\n",
+    "    safe_name = \"\".join(c if c.isalnum() else \"_\" for c in last_question[:40])\n",
+    "    filepath = os.path.join(NOTES_DIR, f\"{safe_name}.md\")\n",
+    "    with open(filepath, \"w\") as f:\n",
+    "        f.write(f\"# {last_question}\\n\\n{last_answer}\")   # full verbatim answer, no summarizing\n",
+    "    return filepath"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef289cd0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chat(message, history, provider_name, expertise):\n",
+    "    provider = PROVIDERS[provider_name]\n",
+    "    client, model = provider[\"client\"], provider[\"model\"]\n",
+    "\n",
+    "    messages = [{\"role\": \"system\", \"content\": EXPERTISE_PROMPTS[expertise] +\n",
+    "                 \" If the user's message is a technical question worth remembering, call save_explanation.\"}]\n",
+    "    for user_msg, bot_msg in history:\n",
+    "        messages.append({\"role\": \"user\", \"content\": user_msg})\n",
+    "        messages.append({\"role\": \"assistant\", \"content\": bot_msg})\n",
+    "    messages.append({\"role\": \"user\", \"content\": message})\n",
+    "\n",
+    "    # Step 1: non-streaming call to check for tool use\n",
+    "    check = client.chat.completions.create(model=model, messages=messages, tools=tools)\n",
+    "    msg = check.choices[0].message\n",
+    "    status = \"\"\n",
+    "\n",
+    "    \n",
+    "\n",
+    "    # Step 2: stream the real answer\n",
+    "    stream = client.chat.completions.create(model=model, messages=messages, stream=True)\n",
+    "    partial = status\n",
+    "    for chunk in stream:\n",
+    "        partial += chunk.choices[0].delta.content or \"\"\n",
+    "        yield partial    \n",
+    "        provider = PROVIDERS[provider_name]\n",
+    "    client, model = provider[\"client\"], provider[\"model\"]\n",
+    "\n",
+    "    messages = [{\"role\": \"system\", \"content\": EXPERTISE_PROMPTS[expertise]}]\n",
+    "    for user_msg, bot_msg in history:\n",
+    "        messages.append({\"role\": \"user\", \"content\": user_msg})\n",
+    "        messages.append({\"role\": \"assistant\", \"content\": bot_msg})\n",
+    "    messages.append({\"role\": \"user\", \"content\": message})\n",
+    "\n",
+    "    stream = client.chat.completions.create(model=model, messages=messages, stream=True)\n",
+    "    partial = \"\"\n",
+    "    for chunk in stream:\n",
+    "        partial += chunk.choices[0].delta.content or \"\"\n",
+    "        yield partial\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1413bb54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with gr.Blocks() as demo:\n",
+    "    chat_ui = gr.ChatInterface(\n",
+    "        fn=chat,\n",
+    "        additional_inputs=[\n",
+    "            gr.Dropdown(list(PROVIDERS.keys()), value=\"Ollama (local)\", label=\"Provider\"),\n",
+    "            gr.Dropdown(list(EXPERTISE_PROMPTS.keys()), value=\"Python Developer\", label=\"Expertise\"),\n",
+    "        ],\n",
+    "    )\n",
+    "    save_btn = gr.Button(\"💾 Save last response to file\")\n",
+    "    file_out = gr.File(label=\"Download\")\n",
+    "    save_btn.click(fn=save_full_response, inputs=[chat_ui.chatbot], outputs=[file_out])\n",
+    "\n",
+    "demo.launch(inbrowser=True, auth=(\"sheri\", \"abc.123\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering (3.12.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Built an interactive multi-provider code/technical-question explainer with a Gradio chat UI, supporting live streaming, switchable LLM providers, persona-based system prompts, and tool-calling for saving responses.

- Multi-provider support (PROVIDERS dict) — Unified config for Ollama (local), Groq, and Gemini using the OpenAI-compatible client pattern (OpenAI(base_url=..., api_key=...)), allowing users to switch models via a UI dropdown without changing code.
- Expertise system prompts (EXPERTISE_PROMPTS dict) — A set of persona-based system prompts (Python Developer, JavaScript Developer, SQL/Data Engineer, Beginner-Friendly Tutor, System Design/Architecture) that let users tailor the depth and framing of explanations to their needs.
- Streaming chat function (chat) — Core chat handler wired to gr.ChatInterface, using stream=True to yield partial responses token-by-token for a live "typing" effect in the UI, while maintaining full conversation history across turns.
- Tool calling (save_explanation + tools schema) — Model-invoked function that logs a short topic/summary of an explanation to a local JSON knowledge base (explanations_log.json), demonstrating OpenAI-compatible function calling across providers.
- Full-response file export (save_full_response) — A UI button (💾 Save last response to file) that writes the verbatim last Q&A pair to a .md file in a notes/ directory and exposes it via gr.File for direct download, avoiding the fidelity loss of a model-generated