### PR TITLE
Add week1 day1 Guardian news summarizer to community-contributions

### DIFF
--- a/week1/community-contributions/day1-guardian-news-summarizer.ipynb
+++ b/week1/community-contributions/day1-guardian-news-summarizer.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Day 1 exercise: news website summarizer\n",
+    "\n",
+    "A variation on the day 1 summarizer that points at The Guardian's international front page.\n",
+    "The system prompt asks the model to skip navigation and boilerplate, and to split out news\n",
+    "and announcements into their own section when the page has any."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openai import OpenAI\n",
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "client = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = \"https://www.theguardian.com/international\"\n",
+    "\n",
+    "response = requests.get(url)\n",
+    "response.raise_for_status()\n",
+    "\n",
+    "soup = BeautifulSoup(response.text, \"html.parser\")\n",
+    "website_content = soup.get_text(separator=\"\\n\")\n",
+    "\n",
+    "# Remove unnecessary blank lines\n",
+    "website_content = \"\\n\".join(\n",
+    "    line.strip()\n",
+    "    for line in website_content.splitlines()\n",
+    "    if line.strip()\n",
+    ")\n",
+    "\n",
+    "# Limit the amount of text sent to the LLM\n",
+    "website_content = website_content[:12000]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are a professional website analyst.\n",
+    "\n",
+    "Your job is to:\n",
+    "- Ignore navigation menus, headers, footers, cookie banners, and repetitive text.\n",
+    "- Focus on the actual content.\n",
+    "- Produce a concise Markdown summary.\n",
+    "- If the website contains news or announcements, summarize them separately.\n",
+    "- Keep the tone friendly and slightly humorous.\n",
+    "\"\"\"\n",
+    "\n",
+    "user_prompt = f\"\"\"\n",
+    "Please analyze the following website.\n",
+    "\n",
+    "Website Content:\n",
+    "----------------\n",
+    "{website_content}\n",
+    "\n",
+    "Provide:\n",
+    "\n",
+    "# Website Summary\n",
+    "\n",
+    "A short overview.\n",
+    "\n",
+    "# Key Points\n",
+    "\n",
+    "- Bullet points\n",
+    "\n",
+    "# News / Announcements\n",
+    "\n",
+    "Only include this section if applicable.\n",
+    "\"\"\"\n",
+    "\n",
+    "messages = [\n",
+    "    {\"role\": \"system\", \"content\": system_prompt},\n",
+    "    {\"role\": \"user\", \"content\": user_prompt},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "completion = client.chat.completions.create(\n",
+    "    model=\"gpt-4.1-nano\",\n",
+    "    messages=messages\n",
+    ")\n",
+    "\n",
+    "display(Markdown(completion.choices[0].message.content))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
A day 1 exercise variation that summarizes The Guardian's international front page.

The system prompt asks the model to ignore navigation and boilerplate, and to break out news and announcements into their own section when the page has any.

Single notebook in week1/community-contributions, outputs cleared.