### PR TITLE
Add Week 2 exercise: Technical Tutor Pro

### DIFF
--- a/week2/community-contributions/technical_tutor_pro_waruts.ipynb
+++ b/week2/community-contributions/technical_tutor_pro_waruts.ipynb
@@ -1,0 +1,490 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9d2e7252",
+   "metadata": {},
+   "source": [
+    "# Week 2 Exercise: Technical Tutor Pro\n",
+    "\n",
+    "This builds on the [Week 1 exercise](../../week1/week1%20EXERCISE.ipynb) (a technical Q&A tool using\n",
+    "GPT-4o-mini and a local Ollama model) and turns it into the full prototype the Week 2 exercise asks for:\n",
+    "\n",
+    "- **Gradio UI** (`gr.Blocks`, following the Day 5 pattern)\n",
+    "- **Streaming** responses, token by token\n",
+    "- A **system prompt** that gives the assistant a technical-tutor persona\n",
+    "- The ability to **switch between models** (OpenAI, Claude, and a local Ollama model)\n",
+    "- **Bonus: tool use** — the tutor can call a `lookup_glossary_term` tool so its answers use this\n",
+    "  course's own definitions of terms like \"RAG\" or \"temperature\" instead of generic ones\n",
+    "- **Bonus: voice in / voice out** — ask by microphone (Whisper transcription) and optionally have the\n",
+    "  answer read back (OpenAI TTS)\n",
+    "\n",
+    "Set `RUN_LOCAL_MODEL = False` below if you don't have Ollama running, and leave `ANTHROPIC_API_KEY`\n",
+    "unset if you don't want the Claude option — both are detected automatically and simply won't appear\n",
+    "in the model dropdown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9aef7590",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "\n",
+    "import os\n",
+    "import json\n",
+    "import tempfile\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "import gradio as gr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55440cd4",
+   "metadata": {},
+   "source": [
+    "## Setting up\n",
+    "\n",
+    "Same pattern as Week 1: load keys from `.env`, and only enable a model if we can actually reach it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5f2c3d72",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenAI API Key exists and begins sk-proj-\n",
+      "Anthropic API Key exists and begins sk-ant-\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set up environment\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "openai_api_key = os.getenv('OPENAI_API_KEY')\n",
+    "anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')\n",
+    "\n",
+    "RUN_LOCAL_MODEL = True  # set False to skip Ollama entirely\n",
+    "OLLAMA_BASE_URL = \"http://localhost:11434/v1\"\n",
+    "LOCAL_MAX_TOKENS = 200  # local CPU models can be slow - keep answers short, as in the Week 1 exercise\n",
+    "\n",
+    "if openai_api_key:\n",
+    "    print(f\"OpenAI API Key exists and begins {openai_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"OpenAI API Key not set\")\n",
+    "\n",
+    "if anthropic_api_key:\n",
+    "    print(f\"Anthropic API Key exists and begins {anthropic_api_key[:7]}\")\n",
+    "else:\n",
+    "    print(\"Anthropic API Key not set - the Claude option will be hidden\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5b9efe80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# constants\n",
+    "\n",
+    "MODEL_GPT = \"gpt-4o-mini\"\n",
+    "MODEL_CLAUDE = \"claude-sonnet-4-5-20250929\"\n",
+    "MODEL_OLLAMA = \"qwen3.5:latest\"  # swap for whatever you have pulled, e.g. llama3.2\n",
+    "\n",
+    "system_message = \"\"\"\n",
+    "You are a friendly, precise technical tutor. You explain code and technical concepts clearly and\n",
+    "concisely to a learner who is following an AI engineering course. Use markdown, and include short\n",
+    "code examples in code blocks whenever they'd help.\n",
+    "\n",
+    "If the learner's question involves a term that might be specific to this course (for example an\n",
+    "LLM engineering concept like RAG, embeddings, temperature, tokens, agents, or fine-tuning), use the\n",
+    "lookup_glossary_term tool to check this course's own definition before answering, so your explanation\n",
+    "lines up with the terminology the learner has already seen.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b640f52",
+   "metadata": {},
+   "source": [
+    "## Connecting to the models\n",
+    "\n",
+    "We reuse the trick from Day 2: point the `OpenAI` client at Anthropic's OpenAI-compatible endpoint so Claude can be called with the same `chat.completions` interface, and do the same for the local Ollama server."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3812ccb6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available models: ['GPT-4o-mini', 'Claude Sonnet', 'Ollama (qwen3.5:latest, local)']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# clients - only create the ones we actually have credentials/access for\n",
+    "\n",
+    "openai_client = OpenAI() if openai_api_key else None\n",
+    "\n",
+    "claude_client = OpenAI(\n",
+    "    api_key=anthropic_api_key,\n",
+    "    base_url=\"https://api.anthropic.com/v1/\"\n",
+    ") if anthropic_api_key else None\n",
+    "\n",
+    "ollama_client = OpenAI(base_url=OLLAMA_BASE_URL, api_key=\"ollama\") if RUN_LOCAL_MODEL else None\n",
+    "\n",
+    "# Model registry for the dropdown: label -> (client, model name, whether it supports our tool)\n",
+    "MODELS = {}\n",
+    "if openai_client:\n",
+    "    MODELS[\"GPT-4o-mini\"] = (openai_client, MODEL_GPT, True)\n",
+    "if claude_client:\n",
+    "    MODELS[\"Claude Sonnet\"] = (claude_client, MODEL_CLAUDE, True)\n",
+    "if ollama_client:\n",
+    "    MODELS[f\"Ollama ({MODEL_OLLAMA}, local)\"] = (ollama_client, MODEL_OLLAMA, False)\n",
+    "\n",
+    "if not MODELS:\n",
+    "    raise RuntimeError(\"No models available - set an API key or start Ollama\")\n",
+    "\n",
+    "print(\"Available models:\", list(MODELS.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "114def16",
+   "metadata": {},
+   "source": [
+    "## Bonus: a glossary tool\n",
+    "\n",
+    "A small, course-specific glossary the tutor can call as a tool. This is deliberately simple - the point is to demonstrate the tool-calling loop from Day 4/5, not to build a real knowledge base."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "90472d58",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TOOL CALLED: lookup_glossary_term('RAG')\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "\"RAG: Retrieval-Augmented Generation: looking up relevant chunks of external text and inserting them into the prompt so the LLM can answer using information it wasn't trained on.\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# the glossary the tool looks up\n",
+    "\n",
+    "GLOSSARY = {\n",
+    "    \"token\": \"A chunk of text (often a word-piece) that an LLM reads or generates one at a time.\",\n",
+    "    \"temperature\": \"A generation setting that controls randomness: near 0 is deterministic and focused, \"\n",
+    "                   \"higher values (e.g. 0.7-1.0) produce more varied, creative output.\",\n",
+    "    \"embedding\": \"A list of numbers (a vector) that represents the meaning of a piece of text, so that \"\n",
+    "                 \"similar meanings end up as nearby vectors.\",\n",
+    "    \"rag\": \"Retrieval-Augmented Generation: looking up relevant chunks of external text and inserting them \"\n",
+    "           \"into the prompt so the LLM can answer using information it wasn't trained on.\",\n",
+    "    \"agent\": \"An LLM that can autonomously decide which tools to call, in what order, to complete a task, \"\n",
+    "             \"rather than just producing a single reply.\",\n",
+    "    \"system prompt\": \"An instruction given to an LLM before the conversation starts, used to set its \"\n",
+    "                      \"persona, tone, or rules of behaviour for the rest of the chat.\",\n",
+    "    \"context window\": \"The maximum number of tokens (prompt + conversation history + generated reply) an \"\n",
+    "                       \"LLM can take into account at once.\",\n",
+    "    \"fine-tuning\": \"Further training an existing model on a smaller, specific dataset so it adapts its \"\n",
+    "                   \"behaviour or knowledge for a particular task.\",\n",
+    "}\n",
+    "\n",
+    "def lookup_glossary_term(term):\n",
+    "    print(f\"TOOL CALLED: lookup_glossary_term({term!r})\", flush=True)\n",
+    "    definition = GLOSSARY.get(term.strip().lower())\n",
+    "    if definition:\n",
+    "        return f\"{term}: {definition}\"\n",
+    "    return f\"No glossary entry for '{term}'. Known terms: {', '.join(GLOSSARY.keys())}\"\n",
+    "\n",
+    "lookup_glossary_term(\"RAG\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "20096983",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the tool's JSON schema, and the tool-call handler\n",
+    "\n",
+    "glossary_function = {\n",
+    "    \"name\": \"lookup_glossary_term\",\n",
+    "    \"description\": \"Look up this course's own definition of an AI/LLM engineering term, e.g. 'RAG' or \"\n",
+    "                   \"'temperature', so explanations use consistent terminology.\",\n",
+    "    \"parameters\": {\n",
+    "        \"type\": \"object\",\n",
+    "        \"properties\": {\n",
+    "            \"term\": {\n",
+    "                \"type\": \"string\",\n",
+    "                \"description\": \"The technical term to look up, e.g. 'embedding'\"\n",
+    "            }\n",
+    "        },\n",
+    "        \"required\": [\"term\"],\n",
+    "        \"additionalProperties\": False\n",
+    "    }\n",
+    "}\n",
+    "tools = [{\"type\": \"function\", \"function\": glossary_function}]\n",
+    "\n",
+    "\n",
+    "def handle_tool_calls(message):\n",
+    "    responses = []\n",
+    "    for tool_call in message.tool_calls:\n",
+    "        if tool_call.function.name == \"lookup_glossary_term\":\n",
+    "            arguments = json.loads(tool_call.function.arguments)\n",
+    "            result = lookup_glossary_term(arguments.get(\"term\", \"\"))\n",
+    "            responses.append({\n",
+    "                \"role\": \"tool\",\n",
+    "                \"content\": result,\n",
+    "                \"tool_call_id\": tool_call.id\n",
+    "            })\n",
+    "    return responses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42f359f5",
+   "metadata": {},
+   "source": [
+    "## Bonus: voice in, voice out\n",
+    "\n",
+    "Whisper turns a recorded question into text; OpenAI TTS turns the final answer back into speech. Both are optional - the app works with typed text and no audio output too."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9c0cff97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# speech-to-text and text-to-speech, both via OpenAI - skipped gracefully if there's no OpenAI key\n",
+    "\n",
+    "def transcribe_audio(audio_filepath):\n",
+    "    if audio_filepath is None or openai_client is None:\n",
+    "        return gr.update()\n",
+    "    with open(audio_filepath, \"rb\") as f:\n",
+    "        transcript = openai_client.audio.transcriptions.create(model=\"whisper-1\", file=f)\n",
+    "    return transcript.text\n",
+    "\n",
+    "\n",
+    "def talker(text):\n",
+    "    if not text or openai_client is None:\n",
+    "        return None\n",
+    "    response = openai_client.audio.speech.create(\n",
+    "        model=\"gpt-4o-mini-tts\",\n",
+    "        voice=\"onyx\",\n",
+    "        input=text\n",
+    "    )\n",
+    "    fd, path = tempfile.mkstemp(suffix=\".mp3\")\n",
+    "    with os.fdopen(fd, \"wb\") as f:\n",
+    "        f.write(response.content)\n",
+    "    return path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f88ebbe4",
+   "metadata": {},
+   "source": [
+    "## Putting it together: streaming + model switching + tools\n",
+    "\n",
+    "Tool calls aren't compatible with streaming in the OpenAI API, so we resolve any tool calls first with a normal (non-streamed) request, then stream the final answer once we know no more tools are needed. The local Ollama model skips the tool step entirely and is capped at `LOCAL_MAX_TOKENS` to stay responsive on CPU, exactly as in the Week 1 exercise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dc89d96d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chat(history, model_choice, read_aloud):\n",
+    "    client, model, supports_tools = MODELS[model_choice]\n",
+    "    messages = [{\"role\": \"system\", \"content\": system_message}] + history\n",
+    "\n",
+    "    if supports_tools:\n",
+    "        response = client.chat.completions.create(model=model, messages=messages, tools=tools)\n",
+    "        while response.choices[0].finish_reason == \"tool_calls\":\n",
+    "            tool_message = response.choices[0].message\n",
+    "            messages.append(tool_message)\n",
+    "            messages.extend(handle_tool_calls(tool_message))\n",
+    "            response = client.chat.completions.create(model=model, messages=messages, tools=tools)\n",
+    "        stream = client.chat.completions.create(model=model, messages=messages, stream=True)\n",
+    "    else:\n",
+    "        stream = client.chat.completions.create(\n",
+    "            model=model, messages=messages, stream=True, max_tokens=LOCAL_MAX_TOKENS\n",
+    "        )\n",
+    "\n",
+    "    history = history + [{\"role\": \"assistant\", \"content\": \"\"}]\n",
+    "    for chunk in stream:\n",
+    "        delta = chunk.choices[0].delta.content or \"\"\n",
+    "        if delta:\n",
+    "            history[-1][\"content\"] += delta\n",
+    "            yield history, None\n",
+    "\n",
+    "    if read_aloud:\n",
+    "        yield history, talker(history[-1][\"content\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ffe1c94",
+   "metadata": {},
+   "source": [
+    "## The Gradio UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "995e1173",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "* Running on local URL:  http://127.0.0.1:7860\n",
+      "* To create a public link, set `share=True` in `launch()`.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><iframe src=\"http://127.0.0.1:7860/\" width=\"100%\" height=\"500\" allow=\"autoplay; camera; microphone; clipboard-read; clipboard-write;\" frameborder=\"0\" allowfullscreen></iframe></div>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": []
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "TOOL CALLED: lookup_glossary_term('RAG')\n",
+      "TOOL CALLED: lookup_glossary_term('Hugging Face')\n"
+     ]
+    }
+   ],
+   "source": [
+    "def user_turn(user_message, history):\n",
+    "    if not user_message:\n",
+    "        return gr.update(), history\n",
+    "    return \"\", history + [{\"role\": \"user\", \"content\": user_message}]\n",
+    "\n",
+    "\n",
+    "with gr.Blocks(title=\"Technical Tutor Pro\") as ui:\n",
+    "    gr.Markdown(\"# \\U0001F393 Technical Tutor Pro\")\n",
+    "    gr.Markdown(\"Ask a technical question by text or voice, pick a model, and optionally hear the answer read back.\")\n",
+    "\n",
+    "    with gr.Row():\n",
+    "        model_choice = gr.Dropdown(choices=list(MODELS.keys()), value=list(MODELS.keys())[0], label=\"Model\")\n",
+    "        read_aloud = gr.Checkbox(label=\"Read the answer aloud\", value=False)\n",
+    "\n",
+    "    chatbot = gr.Chatbot(height=450, type=\"messages\", label=\"Technical Tutor\")\n",
+    "\n",
+    "    with gr.Row():\n",
+    "        message = gr.Textbox(\n",
+    "            label=\"Ask a technical question\",\n",
+    "            placeholder=\"e.g. What does 'yield from' do in Python?\",\n",
+    "            scale=4\n",
+    "        )\n",
+    "        audio_in = gr.Audio(sources=[\"microphone\"], type=\"filepath\", label=\"...or ask by voice\", scale=1)\n",
+    "\n",
+    "    with gr.Row():\n",
+    "        submit_btn = gr.Button(\"Ask\", variant=\"primary\")\n",
+    "        clear_btn = gr.ClearButton([message, chatbot])\n",
+    "\n",
+    "    audio_out = gr.Audio(label=\"Spoken answer\", autoplay=True)\n",
+    "\n",
+    "    audio_in.stop_recording(transcribe_audio, inputs=audio_in, outputs=message)\n",
+    "\n",
+    "    message.submit(user_turn, [message, chatbot], [message, chatbot]).then(\n",
+    "        chat, [chatbot, model_choice, read_aloud], [chatbot, audio_out]\n",
+    "    )\n",
+    "    submit_btn.click(user_turn, [message, chatbot], [message, chatbot]).then(\n",
+    "        chat, [chatbot, model_choice, read_aloud], [chatbot, audio_out]\n",
+    "    )\n",
+    "\n",
+    "ui.launch()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06af0f87",
+   "metadata": {},
+   "source": [
+    "## Where to take this further\n",
+    "\n",
+    "- Add more glossary terms, or swap the glossary tool for a real lookup (e.g. searching the course's own notebooks)\n",
+    "- Add a second tool, so the model has to choose between them\n",
+    "- Persist the glossary lookups so repeated questions about the same term are instant\n",
+    "- Try `gr.ChatInterface` instead of `gr.Blocks` for a simpler UI once you drop the voice/model-switch extras"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Builds on the Week 1 technical Q&A exercise, turning it into the full Week 2 prototype:

- Gradio UI (`gr.Blocks`, following the Day 5 pattern)
- Streaming responses
- A system prompt giving the assistant a technical-tutor persona
- Ability to switch between models: OpenAI GPT-4o-mini, Claude Sonnet, and a local Ollama model (qwen3.5)
- Bonus: a `lookup_glossary_term` tool so answers use this course's own definitions of terms like "RAG" or "temperature"
- Bonus: voice in/out via Whisper transcription and OpenAI TTS

Tested manually end-to-end against all three models, the glossary tool, and audio input/output.