### PR TITLE
Week 1 exercise: technical question explainer (GPT + Ollama)

### DIFF
--- a/community-contributions/alex-huaracha/week1/tech_explainer.ipynb
+++ b/community-contributions/alex-huaracha/week1/tech_explainer.ipynb
@@ -1,0 +1,233 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fe12c203-e6a6-452c-a655-afb8a03a4ff5",
+   "metadata": {},
+   "source": [
+    "# End of week 1 exercise\n",
+    "\n",
+    "To demonstrate your familiarity with OpenAI API, and also Ollama, build a tool that takes a technical question,  \n",
+    "and responds with an explanation. This is a tool that you will be able to use yourself during the course!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1070317-3ed9-4659-abe3-828943230e03",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "\n",
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display, update_display\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a456906-915a-4bfd-bb9d-57e505c5093f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# constants\n",
+    "\n",
+    "MODEL_GPT = 'gpt-4o-mini'\n",
+    "MODEL_LLAMA = 'llama3.2'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8d7923c-5f28-4c30-8556-342d7c8497c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set up environment\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv('OPENAI_API_KEY')\n",
+    "\n",
+    "if api_key and api_key.startswith('sk-proj-') and len(api_key)>10:\n",
+    "    print(\"API key looks good so far\")\n",
+    "else:\n",
+    "    print(\"There might be a problem with your API key? Please visit the troubleshooting notebook!\")\n",
+    "    \n",
+    "openai = OpenAI()\n",
+    "ollama = OpenAI(base_url=\"http://localhost:11434/v1\", api_key='ollama')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcc434ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYSTEM_TEMPLATE = \"\"\"\n",
+    "You are a senior software architect with 15+ years of experience, mentoring a colleague.\n",
+    "\n",
+    "Your audience is an experienced software engineer who is new to LLMs and AI engineering.\n",
+    "Assume solid knowledge of programming, architecture and software design.\n",
+    "Do not assume any knowledge of LLMs, prompts, embeddings or model internals.\n",
+    "\n",
+    "How you explain:\n",
+    "- Lead with the WHY behind a design or behaviour, not just the WHAT.\n",
+    "- Use an analogy only when it clarifies a mechanism that is hard to see. Never force one.\n",
+    "- Show a short code example when it makes the concept concrete.\n",
+    "- Point out trade-offs and failure modes. Never present one approach as the only option.\n",
+    "- Be warm and direct. Skip filler and disclaimers.\n",
+    "\n",
+    "Format:\n",
+    "- Use markdown.\n",
+    "- Keep it concise. Expand only when the concept genuinely requires it.\n",
+    "- Keep technical terms in English (streaming, deployment, generator, embedding).\n",
+    "\n",
+    "Always respond in {language}, regardless of the language of the question.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd680024",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SYSTEM_TEMPLATE_SMALL = \"\"\"\n",
+    "You are a software architect explaining code to an experienced engineer.\n",
+    "\n",
+    "Rules:\n",
+    "- Answer in {language}.\n",
+    "- Use markdown with short sections.\n",
+    "- First explain what the code does, then why it is written that way.\n",
+    "- Be accurate. Do not invent code that was not in the question.\n",
+    "\n",
+    "Example of a good answer:\n",
+    "\n",
+    "Question: Explain what this code does and why: sorted(users, key=lambda u: u[\"age\"])\n",
+    "\n",
+    "Answer:\n",
+    "## Qué hace\n",
+    "Devuelve una nueva lista con los usuarios ordenados por su campo `age`.\n",
+    "\n",
+    "## Por qué\n",
+    "`key` le dice a `sorted` qué valor comparar. El lambda extrae `age` de cada usuario,\n",
+    "así la comparación usa el número y no el objeto entero.\n",
+    "\n",
+    "`sorted` devuelve una lista nueva y deja `users` intacto. Usa `users.sort()` para ordenar in place.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f0d0137-52b0-47a8-81a8-11a90a010798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# here is the question; type over this to ask something new\n",
+    "\n",
+    "question = \"\"\"\n",
+    "Please explain what this code does and why:\n",
+    "yield from {book.get(\"author\") for book in books if book.get(\"author\")}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f179ca2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MODELS = {\n",
+    "    MODEL_GPT:   {\"client\": openai, \"prompt\": SYSTEM_TEMPLATE},\n",
+    "    MODEL_LLAMA: {\"client\": ollama, \"prompt\": SYSTEM_TEMPLATE_SMALL},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10479150",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stream_answer(question, model=MODEL_GPT, language=\"Spanish\"):\n",
+    "    config = MODELS[model]\n",
+    "    stream = config[\"client\"].chat.completions.create(\n",
+    "        model=model,\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": config[\"prompt\"].format(language=language)},\n",
+    "            {\"role\": \"user\", \"content\": question},\n",
+    "        ],\n",
+    "        stream=True,\n",
+    "    )\n",
+    "    answer = \"\"\n",
+    "    for chunk in stream:\n",
+    "        answer += chunk.choices[0].delta.content or \"\"\n",
+    "        yield answer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "185fe69d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(question, model=MODEL_GPT, language=\"Spanish\"):\n",
+    "    handle = display(Markdown(\"\"), display_id=True)\n",
+    "    for partial in stream_answer(question, model=model, language=language):\n",
+    "        update_display(Markdown(partial), display_id=handle.display_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60ce7000-a4a5-4cce-a261-e75ef45063b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get gpt-4o-mini to answer, with streaming\n",
+    "ask(question)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f7c8ea8-4082-4ad0-8751-3301adcf6538",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Llama 3.2 to answer\n",
+    "ask(question, model=MODEL_LLAMA)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering (3.12.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
End of week 1 exercise: a tool that answers technical questions with streaming, using both gpt-4o-mini and llama3.2 via Ollama.

The notebook keeps a small model registry that pairs each model with its client and its own system prompt. llama3.2 gets a shorter prompt with a one-shot example, because the longer instruction-heavy prompt written for gpt-4o-mini makes it drift.

Only adds one file under community-contributions. Outputs are cleared.