### PR TITLE
Add Week 3 exercise: Synthetic Q&A Dataset Generator

### DIFF
--- a/week3/community-contributions/synthetic_qa_dataset_generator_waruts.ipynb
+++ b/week3/community-contributions/synthetic_qa_dataset_generator_waruts.ipynb
@@ -1,0 +1,359 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "341f0ce3",
+   "metadata": {},
+   "source": [
+    "# Week 3 Exercise: Synthetic Q&A Dataset Generator\n",
+    "\n",
+    "The Week 3 challenge is: use a variety of models and prompts to generate a diverse synthetic dataset,\n",
+    "with a Gradio UI, for a real business use case.\n",
+    "\n",
+    "This ties back to the technical tutor built in the [Week 1](../../week1/week1%20EXERCISE.ipynb) and\n",
+    "[Week 2](../../week2/community-contributions/technical_tutor_pro_waruts.ipynb) exercises: instead of a\n",
+    "generic \"fake customer records\" generator, this generates a **question/answer training dataset for a\n",
+    "technical tutor** - genuinely useful for evaluating or fine-tuning it later in the course.\n",
+    "\n",
+    "Three models play three different roles, so \"diverse outputs from a variety of models\" actually means\n",
+    "something rather than just picking a random model per row:\n",
+    "\n",
+    "- One model **writes the questions**\n",
+    "- A different model **writes the answers** (so it isn't grading its own homework)\n",
+    "- A third model acts as a **judge**, scoring each pair 1-5 and filtering out weak ones before they land\n",
+    "  in the final dataset\n",
+    "\n",
+    "Set `RUN_LOCAL_MODEL = False` below if you don't have Ollama running, and leave `ANTHROPIC_API_KEY`\n",
+    "unset if you don't want Claude - both are detected automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3191b0a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "\n",
+    "import os\n",
+    "import re\n",
+    "import json\n",
+    "import tempfile\n",
+    "from dotenv import load_dotenv\n",
+    "from openai import OpenAI\n",
+    "import pandas as pd\n",
+    "import gradio as gr"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8922e929",
+   "metadata": {},
+   "source": [
+    "## Setting up\n",
+    "\n",
+    "Same pattern as Week 1 and Week 2: load keys from `.env`, only enable a model if we can actually reach it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "eb46687b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OpenAI API Key exists and begins sk-proj-\n",
+      "Anthropic API Key exists and begins sk-ant-\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set up environment\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "openai_api_key = os.getenv('OPENAI_API_KEY')\n",
+    "anthropic_api_key = os.getenv('ANTHROPIC_API_KEY')\n",
+    "\n",
+    "RUN_LOCAL_MODEL = True  # set False to skip Ollama entirely\n",
+    "OLLAMA_BASE_URL = \"http://localhost:11434/v1\"\n",
+    "LOCAL_MAX_TOKENS = 300  # local CPU models can be slow - keep answers bounded, as in the Week 1/2 exercises\n",
+    "\n",
+    "if openai_api_key:\n",
+    "    print(f\"OpenAI API Key exists and begins {openai_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"OpenAI API Key not set\")\n",
+    "\n",
+    "if anthropic_api_key:\n",
+    "    print(f\"Anthropic API Key exists and begins {anthropic_api_key[:7]}\")\n",
+    "else:\n",
+    "    print(\"Anthropic API Key not set - the Claude option will be hidden\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "11d84830",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Available models: ['GPT-4o-mini', 'Claude Sonnet', 'Ollama (qwen3.5:latest, local)']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# constants and clients - only create the ones we actually have credentials/access for\n",
+    "\n",
+    "MODEL_GPT = \"gpt-4o-mini\"\n",
+    "MODEL_CLAUDE = \"claude-sonnet-4-5-20250929\"\n",
+    "MODEL_OLLAMA = \"qwen3.5:latest\"  # swap for whatever you have pulled, e.g. llama3.2\n",
+    "\n",
+    "openai_client = OpenAI() if openai_api_key else None\n",
+    "\n",
+    "claude_client = OpenAI(\n",
+    "    api_key=anthropic_api_key,\n",
+    "    base_url=\"https://api.anthropic.com/v1/\"\n",
+    ") if anthropic_api_key else None\n",
+    "\n",
+    "ollama_client = OpenAI(base_url=OLLAMA_BASE_URL, api_key=\"ollama\") if RUN_LOCAL_MODEL else None\n",
+    "\n",
+    "# label -> (client, model name)\n",
+    "MODELS = {}\n",
+    "if openai_client:\n",
+    "    MODELS[\"GPT-4o-mini\"] = (openai_client, MODEL_GPT)\n",
+    "if claude_client:\n",
+    "    MODELS[\"Claude Sonnet\"] = (claude_client, MODEL_CLAUDE)\n",
+    "if ollama_client:\n",
+    "    MODELS[f\"Ollama ({MODEL_OLLAMA}, local)\"] = (ollama_client, MODEL_OLLAMA)\n",
+    "\n",
+    "if len(MODELS) < 2:\n",
+    "    raise RuntimeError(\"Need at least 2 models available (e.g. an API key plus Ollama) to fill the three roles usefully\")\n",
+    "\n",
+    "print(\"Available models:\", list(MODELS.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4a4cacc",
+   "metadata": {},
+   "source": [
+    "## The three roles\n",
+    "\n",
+    "One `chat_once` helper, reused for all three roles (question-writer, answer-writer, judge) - they only differ in system prompt and how the response gets parsed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eda46704",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chat_once(model_choice, system_prompt, user_prompt):\n",
+    "    client, model = MODELS[model_choice]\n",
+    "    kwargs = {\"max_tokens\": LOCAL_MAX_TOKENS} if model == MODEL_OLLAMA else {}\n",
+    "    response = client.chat.completions.create(\n",
+    "        model=model,\n",
+    "        messages=[\n",
+    "            {\"role\": \"system\", \"content\": system_prompt},\n",
+    "            {\"role\": \"user\", \"content\": user_prompt}\n",
+    "        ],\n",
+    "        **kwargs\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "def extract_json(text):\n",
+    "    # models sometimes wrap JSON in markdown fences or add a sentence of preamble -\n",
+    "    # grab the first top-level [...] or {...} block and parse that\n",
+    "    match = re.search(r\"(\\[.*\\]|\\{.*\\})\", text, re.DOTALL)\n",
+    "    if not match:\n",
+    "        raise ValueError(f\"No JSON found in model output: {text!r}\")\n",
+    "    return json.loads(match.group(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ebca466b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_questions(model_choice, topic, difficulty, count):\n",
+    "    system_prompt = (\n",
+    "        \"You are an expert question-setter building a technical quiz dataset. \"\n",
+    "        \"Respond with ONLY a JSON array of strings - no other text, no markdown fences.\"\n",
+    "    )\n",
+    "    user_prompt = (\n",
+    "        f\"Write {count} distinct, well-formed technical questions about '{topic}', \"\n",
+    "        f\"suitable for a {difficulty.lower()} learner. Vary the phrasing and angle of each question so \"\n",
+    "        f\"they don't feel repetitive. Return them as a JSON array of strings.\"\n",
+    "    )\n",
+    "    questions = extract_json(chat_once(model_choice, system_prompt, user_prompt))\n",
+    "    return [str(q).strip() for q in questions][:count]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "30f623e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_answer(model_choice, question, difficulty):\n",
+    "    system_prompt = (\n",
+    "        f\"You are a precise technical tutor. Answer the learner's question clearly and correctly, \"\n",
+    "        f\"pitched at a {difficulty.lower()} level. Use markdown, with short code examples in code \"\n",
+    "        f\"blocks where they would help.\"\n",
+    "    )\n",
+    "    return chat_once(model_choice, system_prompt, question).strip()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e7e076ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def judge_pair(model_choice, question, answer, difficulty):\n",
+    "    system_prompt = (\n",
+    "        \"You are a strict technical reviewer grading a question-answer pair for a training dataset. \"\n",
+    "        \"Respond with ONLY a JSON object: {\\\"score\\\": <integer 1-5>, \\\"notes\\\": \\\"<one short sentence>\\\", \"\n",
+    "        \"\\\"assessed_difficulty\\\": \\\"<Beginner, Intermediate, or Advanced>\\\"}. \"\n",
+    "        \"5 = accurate, clear and complete. 1 = wrong or unusable. \"\n",
+    "        \"assessed_difficulty is your own honest judgement of the level this pair actually reads at - \"\n",
+    "        \"it does not need to match the level it was written for.\"\n",
+    "    )\n",
+    "    user_prompt = f\"Question: {question}\\n\\nAnswer: {answer}\\n\\n(Written for a {difficulty} learner.)\"\n",
+    "    try:\n",
+    "        result = extract_json(chat_once(model_choice, system_prompt, user_prompt))\n",
+    "        score = int(result.get(\"score\", 0))\n",
+    "        notes = str(result.get(\"notes\", \"\")).strip()\n",
+    "        assessed_difficulty = str(result.get(\"assessed_difficulty\", \"\")).strip()\n",
+    "        return score, notes, assessed_difficulty\n",
+    "    except Exception as e:\n",
+    "        return 0, f\"Could not parse judge output ({e})\", \"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9834ccac",
+   "metadata": {},
+   "source": [
+    "## Putting it together\n",
+    "\n",
+    "One generator function drives the whole pipeline: generate all the questions up front, then for each one generate an answer and get it judged, yielding progress after every row so the Gradio UI can update live instead of freezing until everything is done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "27cf8900",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_dataset(topic, difficulty, count, q_model, a_model, judge_model, min_score, progress=gr.Progress()):\n",
+    "    if not topic.strip():\n",
+    "        raise gr.Error(\"Please enter a topic\")\n",
+    "\n",
+    "    rows = []\n",
+    "    yield pd.DataFrame(rows), f\"Generating {count} questions about '{topic}'...\", None\n",
+    "\n",
+    "    questions = generate_questions(q_model, topic, difficulty, count)\n",
+    "\n",
+    "    for i, question in enumerate(questions):\n",
+    "        progress((i + 1) / len(questions), desc=f\"Answering & judging {i + 1}/{len(questions)}\")\n",
+    "        answer = generate_answer(a_model, question, difficulty)\n",
+    "        score, notes, assessed_difficulty = judge_pair(judge_model, question, answer, difficulty)\n",
+    "        rows.append({\n",
+    "            \"topic\": topic,\n",
+    "            \"difficulty\": difficulty,\n",
+    "            \"question\": question,\n",
+    "            \"question_model\": q_model,\n",
+    "            \"answer\": answer,\n",
+    "            \"answer_model\": a_model,\n",
+    "            \"judge_score\": score,\n",
+    "            \"judge_notes\": notes,\n",
+    "            \"judge_model\": judge_model,\n",
+    "            \"assessed_difficulty\": assessed_difficulty,\n",
+    "            \"difficulty_match\": assessed_difficulty.lower() == difficulty.lower(),\n",
+    "            \"kept\": score >= min_score\n",
+    "        })\n",
+    "        yield pd.DataFrame(rows), f\"Generated {i + 1}/{len(questions)} pairs...\", None\n",
+    "\n",
+    "    df = pd.DataFrame(rows)\n",
+    "    kept_df = df[df[\"kept\"]]\n",
+    "\n",
+    "    fd, path = tempfile.mkstemp(suffix=\".jsonl\")\n",
+    "    with os.fdopen(fd, \"w\") as f:\n",
+    "        for _, row in kept_df.iterrows():\n",
+    "            f.write(json.dumps({\n",
+    "                \"question\": row[\"question\"],\n",
+    "                \"answer\": row[\"answer\"],\n",
+    "                \"topic\": row[\"topic\"],\n",
+    "                \"difficulty\": row[\"difficulty\"],\n",
+    "            }) + \"\\n\")\n",
+    "\n",
+    "    mismatches = (~df[\"difficulty_match\"]).sum()\n",
+    "    yield df, f\"Done: {len(kept_df)}/{len(df)} pairs kept (score >= {min_score}). {mismatches} difficulty mismatch(es).\", path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3c25c2f",
+   "metadata": {},
+   "source": [
+    "## The Gradio UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e40f27fe",
+   "metadata": {},
+   "outputs": [],
+   "source": "default_models = list(MODELS.keys())\n\nwith gr.Blocks(title=\"Synthetic Q&A Dataset Generator\") as ui:\n    gr.Markdown(\"# 🧪 Synthetic Q&A Dataset Generator\")\n    gr.Markdown(\n        \"Generate a quality-controlled technical Q&A dataset using three models in three different \"\n        \"roles: one writes questions, one writes answers, one judges the pairs.\"\n    )\n\n    with gr.Row():\n        topic = gr.Textbox(label=\"Topic\", placeholder=\"e.g. Python generators, RAG, Docker networking\", scale=2)\n        difficulty = gr.Dropdown([\"Beginner\", \"Intermediate\", \"Advanced\"], value=\"Intermediate\", label=\"Difficulty\")\n        count = gr.Slider(3, 20, value=5, step=1, label=\"Number of Q&A pairs\")\n\n    with gr.Row():\n        q_model = gr.Dropdown(default_models, value=default_models[0], label=\"Question model\")\n        a_model = gr.Dropdown(default_models, value=default_models[min(1, len(default_models) - 1)], label=\"Answer model\")\n        judge_model = gr.Dropdown(default_models, value=default_models[0], label=\"Judge model\")\n\n    min_score = gr.Slider(1, 5, value=3, step=1, label=\"Minimum judge score to keep\")\n\n    generate_btn = gr.Button(\"Generate dataset\", variant=\"primary\")\n    status = gr.Markdown(\"\")\n    table = gr.Dataframe(\n        headers=[\"topic\", \"difficulty\", \"question\", \"question_model\", \"answer\", \"answer_model\",\n                 \"judge_score\", \"judge_notes\", \"judge_model\", \"assessed_difficulty\", \"difficulty_match\", \"kept\"],\n        column_widths=[\"100px\", \"90px\", \"280px\", \"110px\", \"320px\", \"110px\",\n                       \"70px\", \"200px\", \"110px\", \"120px\", \"100px\", \"70px\"],\n        wrap=True,\n        max_height=600\n    )\n    download = gr.File(label=\"Download kept pairs (JSONL)\")\n\n    generate_btn.click(\n        generate_dataset,\n        inputs=[topic, difficulty, count, q_model, a_model, judge_model, min_score],\n        outputs=[table, status, download]\n    )\n\nui.launch()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb0ab9f6",
+   "metadata": {},
+   "source": [
+    "## Where to take this further\n",
+    "\n",
+    "- Add a fourth role: a model that rewrites low-scoring pairs instead of just discarding them\n",
+    "- Feed the kept JSONL straight into a fine-tuning run for the Week 1/2 technical tutor\n",
+    "- Track cost/latency per model to compare providers on this task, not just answer quality"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Builds on the Week 1/2 technical tutor by generating a synthetic Q&A training dataset for it, using three models in three distinct roles so "diverse outputs from a variety of models" is structural rather than cosmetic:

- One model writes the questions for a given topic/difficulty
- A different model writes the answers, so it isn't grading its own homework
- A third model judges each pair (1-5 score + notes) and separately assesses what difficulty level the pair actually reads at, flagging mismatches against what was requested

Only pairs at or above a user-set minimum score are kept in the final JSONL export; the full generation table (including filtered-out and mismatched rows) stays visible in the UI for inspection.

**Gradio UI:** topic/difficulty/count inputs, independent model pickers for each of the three roles, live per-row progress during generation, a tuned-width dataframe preview, and a JSONL download of the kept pairs.

Smoke-tested the generation pipeline end-to-end (question generation, answer generation, judging, JSON parsing, difficulty-match detection, file export) and manually verified the Gradio UI.