### PR TITLE
Add content image and post creator chatbot (community contribution)

### DIFF
--- a/week2/community-contributions/content_image_and_post_creator.ipynb
+++ b/week2/community-contributions/content_image_and_post_creator.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Image and Post Content Creator Chatbot\n\nGiven a **topic/theme**, this project:\n\n1. 🎨 Generates a related **image** (gpt-image-1-mini),\n2. ✍️ Generates a **short, catchy caption** to overlay on the image,\n3. 📖 Generates an inspiring **quote from a book**,\n\nand combines all three into a single image, ready to share on social media.\n\nIt brings together everything we learned in Week 2: **structured output**, **image generation**, and building a **chatbot UI with Gradio**."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# imports\n\nimport os\nimport json\nimport base64\nfrom io import BytesIO\n\nfrom dotenv import load_dotenv\nfrom openai import OpenAI\nimport gradio as gr\nfrom PIL import Image, ImageDraw, ImageFont"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialization\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "\n",
+    "openai_api_key = os.getenv('OPENAI_API_KEY')\n",
+    "if openai_api_key:\n",
+    "    print(f\"OpenAI API Key exists and begins {openai_api_key[:8]}\")\n",
+    "else:\n",
+    "    print(\"OpenAI API Key not set\")\n",
+    "\n",
+    "MODEL = \"gpt-4.1-mini\"\n",
+    "IMAGE_MODEL = \"gpt-image-1-mini\"\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Content generation (caption + quote + image description)\n\nWith a single LLM call, using **structured output** (`json_schema`), we generate three things at once:\n\n- `image_prompt`: an English description to hand to the image generation model\n- `caption`: a short, catchy caption to overlay on the image\n- `quote`: an inspiring quote from a book\n- `quote_source`: the source of the quote (Author — Book Title)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "system_message = \"\"\"\nYou are a creative content assistant who prepares inspiring image posts for social media.\nThe user will give you a topic/theme (e.g. 'solitude', 'hope', 'the ocean', 'new beginnings').\n\nBased on this theme, generate the following:\n1. image_prompt: A vivid, artistic image description, written in ENGLISH, for the image generation model.\n   - The background, setting, color palette, and art style (e.g. photography, oil painting, watercolor,\n     digital art, minimalist, surreal, cinematic) MUST be chosen specifically to fit the meaning of the\n     theme, not a generic default.\n   - Vary the art style and composition from theme to theme - avoid reusing the same visual formula\n     (e.g. don't always default to vibrant pop-art) so that different topics produce visibly different images.\n2. caption: A short, catchy caption, in ENGLISH, at most 8-10 words, to overlay on the image.\n3. quote: A real quote from a book, in ENGLISH, related to the theme.\n4. quote_source: The source of the quote, formatted as 'Author Name — Book Title'.\n\nAlways generate valid, theme-appropriate content.\n\"\"\"\n\nCONTENT_SCHEMA = {\n    \"type\": \"json_schema\",\n    \"json_schema\": {\n        \"name\": \"content_package\",\n        \"schema\": {\n            \"type\": \"object\",\n            \"properties\": {\n                \"image_prompt\": {\"type\": \"string\", \"description\": \"English prompt for the image generation model\"},\n                \"caption\": {\"type\": \"string\", \"description\": \"Short English caption to overlay on the image\"},\n                \"quote\": {\"type\": \"string\", \"description\": \"A quote from a book, in English\"},\n                \"quote_source\": {\"type\": \"string\", \"description\": \"Author — Book name\"}\n            },\n            \"required\": [\"image_prompt\", \"caption\", \"quote\", \"quote_source\"],\n            \"additionalProperties\": False\n        },\n        \"strict\": True\n    }\n}"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def generate_content(topic):\n    messages = [\n        {\"role\": \"system\", \"content\": system_message},\n        {\"role\": \"user\", \"content\": f\"Topic: {topic}\"}\n    ]\n    response = openai.chat.completions.create(\n        model=MODEL,\n        messages=messages,\n        response_format=CONTENT_SCHEMA\n    )\n    return json.loads(response.choices[0].message.content)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Let's try it out\n\ngenerate_content(\"hope\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 2. Image generation\n\nWe use `gpt-image-1-mini` to generate the image from `image_prompt`.\n\n### Price alert: Each image generation costs a few cents - don't go overboard while testing!"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def artist(image_prompt):\n    image_response = openai.images.generate(\n        model=IMAGE_MODEL,\n        prompt=image_prompt,\n        size=\"1024x1024\",\n        n=1,\n    )\n    image_base64 = image_response.data[0].b64_json\n    image_data = base64.b64decode(image_base64)\n    return Image.open(BytesIO(image_data))"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 3. Overlaying text on the image\n\nWe place the `caption` at the top and the `quote` + `quote_source` at the bottom of the generated image,\non semi-transparent bands, word-wrapped for readability."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _load_font(size):\n",
+    "    candidates = [\n",
+    "        \"/System/Library/Fonts/Supplemental/Arial Bold.ttf\",  # macOS\n",
+    "        \"/System/Library/Fonts/Supplemental/Arial.ttf\",\n",
+    "        \"/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf\",  # Linux\n",
+    "        \"C:/Windows/Fonts/arialbd.ttf\",  # Windows\n",
+    "    ]\n",
+    "    for path in candidates:\n",
+    "        if os.path.exists(path):\n",
+    "            return ImageFont.truetype(path, size)\n",
+    "    return ImageFont.load_default()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def wrap_text(draw, text, font, max_width):\n",
+    "    words = text.split()\n",
+    "    lines = []\n",
+    "    current = \"\"\n",
+    "    for word in words:\n",
+    "        trial = f\"{current} {word}\".strip()\n",
+    "        if draw.textlength(trial, font=font) <= max_width:\n",
+    "            current = trial\n",
+    "        else:\n",
+    "            if current:\n",
+    "                lines.append(current)\n",
+    "            current = word\n",
+    "    if current:\n",
+    "        lines.append(current)\n",
+    "    return lines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def add_text_overlay(image, caption, quote, quote_source):\n    image = image.convert(\"RGBA\")\n    width, height = image.size\n    overlay = Image.new(\"RGBA\", image.size, (0, 0, 0, 0))\n    draw = ImageDraw.Draw(overlay)\n\n    padding = int(width * 0.05)\n    max_width = width - 2 * padding\n\n    caption_font = _load_font(int(width * 0.055))\n    quote_font = _load_font(int(width * 0.032))\n    source_font = _load_font(int(width * 0.026))\n\n    caption_lines = wrap_text(draw, caption, caption_font, max_width)\n    quote_lines = wrap_text(draw, f\"“{quote}”\", quote_font, max_width)\n\n    line_spacing = 10\n\n    # Top band: caption\n    caption_line_height = caption_font.getbbox(\"Ag\")[3] + line_spacing\n    caption_block_height = caption_line_height * len(caption_lines) + padding\n    draw.rectangle([(0, 0), (width, caption_block_height)], fill=(0, 0, 0, 140))\n\n    y = padding // 2\n    for line in caption_lines:\n        line_width = draw.textlength(line, font=caption_font)\n        draw.text(((width - line_width) / 2, y), line, font=caption_font, fill=(255, 255, 255, 255))\n        y += caption_line_height\n\n    # Bottom band: quote + source\n    quote_line_height = quote_font.getbbox(\"Ag\")[3] + line_spacing\n    source_height = source_font.getbbox(\"Ag\")[3] + line_spacing\n    bottom_block_height = quote_line_height * len(quote_lines) + source_height + padding\n\n    draw.rectangle([(0, height - bottom_block_height), (width, height)], fill=(0, 0, 0, 140))\n\n    y = height - bottom_block_height + padding // 2\n    for line in quote_lines:\n        line_width = draw.textlength(line, font=quote_font)\n        draw.text(((width - line_width) / 2, y), line, font=quote_font, fill=(255, 255, 255, 255))\n        y += quote_line_height\n\n    source_width = draw.textlength(quote_source, font=source_font)\n    draw.text(((width - source_width) / 2, y), quote_source, font=source_font, fill=(230, 230, 230, 255))\n\n    return Image.alpha_composite(image, overlay).convert(\"RGB\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 4. Putting it all together"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_post(topic):\n",
+    "    content = generate_content(topic)\n",
+    "    image = artist(content[\"image_prompt\"])\n",
+    "    final_image = add_text_overlay(image, content[\"caption\"], content[\"quote\"], content[\"quote_source\"])\n",
+    "    return final_image, content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Let's try it out\n\nfinal_image, content = create_post(\"new beginnings\")\ndisplay(final_image)\ncontent"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 5. Gradio chatbot interface\n\nThe user types a topic; the chat panel shows the generated caption and quote, while the panel on the\nright shows the final image with the text overlaid."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def chat(history):\n    history = [{\"role\": h[\"role\"], \"content\": h[\"content\"]} for h in history]\n    topic = history[-1][\"content\"]\n\n    content = generate_content(topic)\n    image = artist(content[\"image_prompt\"])\n    final_image = add_text_overlay(image, content[\"caption\"], content[\"quote\"], content[\"quote_source\"])\n\n    reply = (\n        f\"**Caption:** {content['caption']}\\n\\n\"\n        f\"**Quote:** \\\"{content['quote']}\\\"\\n\"\n        f\"— {content['quote_source']}\"\n    )\n    history += [{\"role\": \"assistant\", \"content\": reply}]\n\n    return history, final_image"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "def put_message_in_chatbot(message, history):\n    return \"\", history + [{\"role\": \"user\", \"content\": message}]\n\nwith gr.Blocks() as ui:\n    with gr.Row():\n        chatbot = gr.Chatbot(height=500, type=\"messages\", label=\"Caption & Quote\")\n        image_output = gr.Image(height=500, interactive=False, label=\"Generated Image\")\n    with gr.Row():\n        message = gr.Textbox(label=\"Enter a topic/theme (e.g. hope, ocean, solitude):\")\n\n    message.submit(put_message_in_chatbot, inputs=[message, chatbot], outputs=[message, chatbot]).then(\n        chat, inputs=chatbot, outputs=[chatbot, image_output]\n    )\n\nui.launch(inbrowser=True)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ideas / Extensions\n\n- Add a user-selectable image **style** (pop-art, watercolor, minimalist...) as a parameter.\n- Integrate a real quote database/search tool (tool calling) to verify `quote_source`.\n- Automatically save the generated image to disk and present it in a gallery.\n- Change the `size` parameter to support different aspect ratios (Instagram post / story)."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- New community contribution notebook: `week2/community-contributions/content_image_and_post_creator.ipynb`
- Given a topic/theme, generates a themed image (`gpt-image-1-mini`), a short caption, and a book quote via structured output, then overlays the caption/quote on the image
- Includes a simple Gradio chat UI to try it interactively

## Test plan
- [x] Ran all cells (excluding the final `ui.launch`) end-to-end with a real `OPENAI_API_KEY` and confirmed content generation, image generation, and text overlay all work correctly