### PR TITLE
Add Day 2 Ollama webpage summarizer community contribution

### DIFF
--- a/community-contributions/kcafernandes/day2_ollamaWebsiteScraper.ipynb
+++ b/community-contributions/kcafernandes/day2_ollamaWebsiteScraper.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "eea6810d",
+   "metadata": {},
+   "source": [
+    "Website scraper using ollama API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86323cdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ollama pull llama3.2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19cca91e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from scraper import fetch_website_contents\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "web = fetch_website_contents(\"insert website here\")\n",
+    "print(web)\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "You are a snarky assistant that analyzes the contents of a website,\n",
+    "and provides a short, snarky, humorous summary.\n",
+    "Respond in markdown. Do not wrap the markdown in a code block - respond just with the markdown.\n",
+    "\"\"\"\n",
+    "\n",
+    "user_prompt = \"\"\"\n",
+    "Here are the contents of a website.\n",
+    "Provide a short summary of this website.\n",
+    "\"\"\"\n",
+    "\n",
+    "messages = [\n",
+    "    {\"role\" : \"system\" , \"content\" : system_prompt},\n",
+    "    {\"role\" : \"user\" , \"content\" : user_prompt + \"\\n\\nWebsite contents:\\n\" + web}\n",
+    "]\n",
+    "\n",
+    "from ollama import chat\n",
+    "\n",
+    "response = chat(\n",
+    "    model=\"llama3.2\",\n",
+    "    messages=messages\n",
+    ")\n",
+    "\n",
+    "Markdown(response.message.content)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Contribution

Added my Day 2 community contribution using Ollama and a locally running Llama 3.2 model.

- scrapes webpage content
- sends the cleaned content to a local LLM through Ollama
- generates a short webpage summary
- avoids the need for a paid OpenAI API call

This is an implementation of the Day 2 local-model