### PR TITLE
Add Company Brochure Generator (Week 1 community contribution)

### DIFF
--- a/community-contributions/company-brochure-project/.gitignore
+++ b/community-contributions/company-brochure-project/.gitignore
@@ -1,0 +1,30 @@
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+*.egg-info/
+build/
+dist/
+
+# Environment variables
+.env
+.env.*
+
+# Virtual environments (project uses the shared week1/llm_engineering .venv)
+.venv/
+venv/
+env/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/community-contributions/company-brochure-project/README.md
+++ b/community-contributions/company-brochure-project/README.md
@@ -1,0 +1,220 @@
+# Company Brochure Generator
+
+## Overview
+
+**Company Brochure Generator** is a small AI engineering project that automatically produces a professional company brochure from nothing more than a company name and a website URL.
+
+It scrapes the target website, uses a locally-running **Llama 3.2** model (served via **Ollama**) to decide which pages are actually worth reading (About, Careers, Team, Products, etc.), scrapes those pages too, and then asks the model to synthesize everything into a clean Markdown brochure — streamed back to the user as it's generated.
+
+This project is a refactored, production-style version of the `day5.ipynb` notebook from Week 1 of the `llm_engineering` course repository. All original behavior has been preserved; only the code organization has changed.
+
+## Features
+
+-  **Automatic web scraping** of a company's landing page and its internal links.
+-  **LLM-based link triage** — Llama 3.2 reads the raw list of links on a page and decides which ones are relevant to a company brochure (About, Careers, Team, Products, Case Studies, Press, etc.), while ignoring noise (ToS, privacy policy, social links, anchors, duplicates).
+-  **LLM-based brochure generation** — a second call to Llama 3.2 synthesizes all the scraped content into a concise, professional Markdown brochure.
+-  **Streaming output** with a typewriter-style animation (via `IPython.display`) when run in a Jupyter environment.
+-  **100% local & free** — runs entirely against a local Ollama server, so no paid API key is required and no website data leaves the machine.
+-  **OpenAI-compatible client** — built on the standard `openai` Python SDK, pointed at Ollama's OpenAI-compatible endpoint, so swapping back to real OpenAI models is a one-line change (kept commented in the source for reference).
+
+## Project Architecture
+
+The pipeline uses two sequential LLM calls, sandwiched between scraping steps:
+
+1. Scrape the company's landing page to get its raw list of links.
+2. Ask Llama 3.2 to select which of those links are relevant to a brochure.
+3. Scrape the content of the landing page and every relevant linked page.
+4. Ask Llama 3.2 to turn all of that scraped content into a Markdown brochure.
+5. Stream the result back to the user.
+
+### Mermaid Workflow Diagram
+
+```mermaid
+flowchart TD
+    A[User provides company name and URL] --> B[Scraper: fetch landing page links]
+    B --> C[Llama 3.2 via Ollama: select relevant links]
+    C --> D[Scraper: fetch landing page content]
+    C --> E[Scraper: fetch content of each relevant link]
+    D --> F[Assemble combined website content]
+    E --> F
+    F --> G[Build brochure prompt]
+    G --> H[Llama 3.2 via Ollama: generate brochure]
+    H --> I[Stream Markdown brochure to the user]
+```
+
+## Project Structure
+
+```text
+company_brochure_project/
+│
+├── README.md
+├── .gitignore
+│
+├── src/
+│   ├── main.py        # Entry point: user interaction, orchestration
+│   ├── scraper.py      # HTTP requests + BeautifulSoup HTML cleaning
+│   ├── links.py         # LLM-based relevant-link selection
+│   ├── brochure.py      # Content assembly + brochure generation/streaming
+│   ├── llm.py            # Ollama / OpenAI-compatible client setup
+│   ├── prompts.py         # All system and user prompts
+│   └── utils.py            # Small shared helpers (truncation, JSON parsing)
+│
+└── assets/
+    └── (optional screenshots)
+```
+
+## Requirements
+
+- Python 3.12+
+- [Ollama](https://ollama.com/) installed and running locally, with the `llama3.2` model pulled:
+
+  ```bash
+  ollama pull llama3.2
+  ollama serve
+  ```
+
+- The Python dependencies already defined in the shared `llm_engineering` environment: `beautifulsoup4`, `requests`, `python-dotenv`, `openai`, `ipython`.
+
+## Shared UV Environment
+
+This project **does not** define its own `pyproject.toml`, `uv.lock`, `requirements.txt`, or `.venv`. It is designed to live inside the larger `llm_engineering` repository and use its **shared** UV-managed environment:
+
+```text
+llm_engineering/
+│
+├── pyproject.toml
+├── uv.lock
+├── .venv/
+│
+└── week1/
+    └── company_brochure_project/
+```
+
+All dependencies (BeautifulSoup, requests, python-dotenv, openai, IPython, etc.) are expected to already be declared in the root-level `pyproject.toml` / `uv.lock` and installed into the shared `.venv`. Run everything from the activated shared environment.
+
+## Installation
+
+From the root of the `llm_engineering` repository:
+
+```bash
+# Sync the shared environment (only needs to be done once, at the repo root)
+uv sync
+
+# Activate the shared virtual environment
+source .venv/bin/activate   # macOS / Linux
+# .venv\Scripts\activate    # Windows
+```
+
+No further installation is required inside `week1/company_brochure_project/` itself.
+
+## Running the Project
+
+Make sure Ollama is running locally with `llama3.2` pulled, then, from the shared environment:
+
+```bash
+cd week1/company_brochure_project/src
+python main.py
+```
+
+You will be prompted for:
+
+1. The company name
+2. The company website URL
+
+The brochure will then stream to the console (and render as animated Markdown if run inside a Jupyter environment).
+
+## Example Usage
+
+```text
+Enter the company name: HuggingFace
+Enter the company website URL (e.g. https://example.com): https://huggingface.co
+
+Generating brochure for 'HuggingFace' (https://huggingface.co) using local Llama 3.2 via Ollama...
+Selecting relevant links for https://huggingface.co by calling llama3.2
+Found 6 relevant links
+```
+
+## Example Output
+
+```markdown
+# HuggingFace
+
+## Company Overview
+HuggingFace is a platform and community building the tools that power the
+future of machine learning...
+
+## Products & Services
+- Transformers library
+- Model Hub
+- Datasets Hub
+- Spaces (ML app hosting)
+
+## Careers
+HuggingFace is actively hiring across engineering, research, and community roles...
+```
+
+*(Actual output will vary based on live website content and the local model's response.)*
+
+## Ollama Configuration
+
+The project talks to Ollama through its **OpenAI-compatible** endpoint:
+
+- Base URL: `http://localhost:11434/v1`
+- API key: `"ollama"` (a placeholder value — Ollama does not require real authentication)
+- Model: `llama3.2`
+
+This configuration lives entirely in `src/llm.py`. A commented-out block preserves the original paid-OpenAI configuration (`gpt-5-nano` / `gpt-4.1-mini` + `OPENAI_API_KEY`) for reference, in case a future contributor wants to switch back to a hosted model.
+
+## Limitations
+
+- Relies on the target website allowing scraping and not requiring JavaScript rendering (static HTML only — no headless browser).
+- Link-relevance selection and brochure quality depend on the local `llama3.2` model's judgment and can vary between runs.
+- Website content is truncated (2,000 characters per page, 5,000 characters for the full brochure prompt) to keep prompts within a reasonable size — very large or JS-heavy sites may lose relevant content.
+- No retry logic for transient network failures beyond the individual link try/except in `fetch_page_and_all_relevant_links`.
+- Streaming animation (`update_display`) only renders visually inside a Jupyter/IPython environment; a plain terminal run prints the final Markdown text instead.
+
+## Design Decisions
+
+- **Single-responsibility modules**: each file owns exactly one concern (scraping, prompts, LLM client, link selection, brochure assembly, entry point), mirroring the notebook's logical sections but making each piece independently testable and reusable.
+- **Prompts centralized in `prompts.py`**: every system prompt and user-prompt builder lives in one place, so prompt engineering changes never require touching business logic.
+- **`llm.py` owns only client setup**: the `MODEL` constant and Ollama/OpenAI client live together so switching providers or models is a one-line change.
+- **No circular imports**: `scraper.py` has no project-internal dependencies; `prompts.py` depends only on `scraper.py`; `links.py` and `brochure.py` depend on `prompts.py`, `llm.py`, `scraper.py`, and `utils.py`; `main.py` depends only on `brochure.py`.
+
+## Refactoring Decisions
+
+- Extracted the shared 2,000/5,000-character truncation logic into `utils.truncate_text` instead of duplicating slice expressions.
+- Extracted `json.loads(...)` into `utils.parse_json_response` so structured-LLM-response parsing has one consistent home.
+- Split the original notebook's `get_brochure_user_prompt(company_name, url)` (which scraped internally) into two clear steps: `brochure.fetch_page_and_all_relevant_links` / `brochure.build_brochure_prompt` (assembly + truncation) and `prompts.get_brochure_user_prompt` (pure prompt text construction, no scraping) — keeping `prompts.py` free of any network calls, per the "no API calls" rule for that module.
+- Added `requests` timeouts and `response.raise_for_status()` calls in `scraper.py` for more robust error surfacing, without changing the returned data shape.
+- Renamed the `openai` client variable to `ollama_client` for clarity, since the OpenAI SDK is only used here as a generic OpenAI-compatible HTTP client for Ollama.
+- Preserved every commented-out "OpenAI / GPT Version" code block from the original notebook (relabeled as reference comments) so the paid-API code path remains visible and easy to restore.
+
+## Learning Objectives
+
+- Using an LLM as a *classifier/router* (selecting relevant links) as one step in a larger multi-call pipeline.
+- Chaining multiple LLM calls together to accomplish a task no single call could do well alone.
+- Running open-weight models locally via Ollama through an OpenAI-compatible API, avoiding both API costs and external data exposure.
+- Structured JSON output parsing from an LLM response.
+- Streaming LLM responses for a better user experience.
+- Refactoring exploratory notebook code into a maintainable, single-responsibility Python project.
+
+## Future Improvements
+
+- Add caching for scraped pages to avoid re-fetching the same URL across runs.
+- Add unit tests (with mocked HTTP and LLM responses) for `scraper.py`, `links.py`, and `brochure.py`.
+- Support headless-browser scraping (e.g. Playwright) for JavaScript-heavy sites.
+- Allow the truncation limits and model name to be configured via environment variables.
+- Add a simple CLI flag interface (e.g. `argparse`) as an alternative to interactive `input()` prompts.
+- Export the generated brochure directly to a `.md` or `.pdf` file.
+
+## License
+
+This project is provided for educational purposes as part of the Week 1 exercises of the `llm_engineering` course repository. No explicit license is granted beyond that context; adapt as needed for your own learning.
+
+## References
+
+- [Ollama](https://ollama.com/)
+- [Ollama OpenAI-compatible API docs](https://github.com/ollama/ollama/blob/main/docs/openai.md)
+- [OpenAI Python SDK](https://github.com/openai/openai-python)
+- [BeautifulSoup documentation](https://www.crummy.com/software/BeautifulSoup/bs4/doc/)
+- [python-dotenv](https://pypi.org/project/python-dotenv/)

--- a/community-contributions/company-brochure-project/src/brochure.py
+++ b/community-contributions/company-brochure-project/src/brochure.py
@@ -1,0 +1,208 @@
+"""
+brochure.py
+-----------
+
+Responsible only for:
+
+* assembling company information (landing page + relevant linked pages)
+* creating the brochure prompt (delegated to prompts.py)
+* generating the brochure
+* streaming the brochure generation
+
+No scraping mechanics or prompt text definitions live here.
+"""
+
+from __future__ import annotations
+
+from links import select_relevant_links
+from llm import MODEL, ollama_client
+from prompts import BROCHURE_SYSTEM_PROMPT, get_brochure_user_prompt
+from scraper import fetch_website_contents
+from utils import truncate_text
+
+# Same limit used in the original notebook when building the brochure prompt.
+MAX_BROCHURE_PROMPT_CHARACTERS: int = 5_000
+
+
+def fetch_page_and_all_relevant_links(url: str) -> str:
+    """
+    Scrape a company's landing page plus every relevant linked page
+    selected by the LLM, and combine them into a single block of text.
+
+    :param url: Full URL of the company's landing page.
+    :return: Combined text of the landing page and successfully fetched
+        relevant linked pages.
+    """
+    contents = fetch_website_contents(url)
+    relevant_links = select_relevant_links(url)
+
+    result = f"## Landing Page:\n\n{contents}\n## Relevant Links:\n"
+
+    for link in relevant_links["links"]:
+        link_url = (link.get("url") or "").strip()
+
+        if not link_url:
+            print(f"Skipping empty URL: {link.get('type', 'unknown link')}")
+            continue
+
+        try:
+            result += f"\n\n### Link: {link.get('type', 'unknown link')}\n"
+            result += fetch_website_contents(link_url)
+
+        except Exception as error:
+            print(f"Skipping unavailable URL: {link_url}")
+            print(f"Reason: {error}")
+
+    return result
+
+
+def build_brochure_prompt(company_name: str, url: str) -> str:
+    """
+    Assemble the website content for a company and build the full brochure
+    user prompt, truncated to MAX_BROCHURE_PROMPT_CHARACTERS.
+
+    :param company_name: Name of the company the brochure is about.
+    :param url: Full URL of the company's landing page.
+    :return: Complete user prompt ready to send to the LLM.
+    """
+    website_content = fetch_page_and_all_relevant_links(url)
+
+    user_prompt = get_brochure_user_prompt(
+        company_name,
+        website_content,
+    )
+
+    return truncate_text(
+        user_prompt,
+        MAX_BROCHURE_PROMPT_CHARACTERS,
+    )
+
+
+def create_brochure(company_name: str, url: str) -> str:
+    """
+    Generate a company brochure in one LLM call.
+
+    This version prints the generated Markdown directly in the terminal.
+
+    :param company_name: Name of the company the brochure is about.
+    :param url: Full URL of the company's landing page.
+    :return: Generated brochure text in Markdown.
+    """
+
+    # ==========================================
+    # OpenAI / GPT Version - Original Code
+    # Kept for reference from the notebook.
+    # ==========================================
+
+    # response = openai_client.chat.completions.create(
+    #     model="gpt-4.1-mini",
+    #     messages=[
+    #         {
+    #             "role": "system",
+    #             "content": BROCHURE_SYSTEM_PROMPT,
+    #         },
+    #         {
+    #             "role": "user",
+    #             "content": build_brochure_prompt(company_name, url),
+    #         },
+    #     ],
+    # )
+
+    # ==========================================
+    # Ollama + Llama 3.2 Version
+    # Active implementation.
+    # ==========================================
+
+    response = ollama_client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": BROCHURE_SYSTEM_PROMPT,
+            },
+            {
+                "role": "user",
+                "content": build_brochure_prompt(company_name, url),
+            },
+        ],
+    )
+
+    result = response.choices[0].message.content
+
+    print("\n--- Company Brochure ---\n")
+    print(result)
+
+    return result
+
+
+def stream_brochure(company_name: str, url: str) -> str:
+    """
+    Generate a company brochure with streaming output directly in the
+    terminal.
+
+    The response is printed chunk-by-chunk to create a typewriter-style
+    effect.
+
+    :param company_name: Name of the company the brochure is about.
+    :param url: Full URL of the company's landing page.
+    :return: Complete generated brochure text in Markdown.
+    """
+
+    # ==========================================
+    # OpenAI / GPT Version - Original Code
+    # Kept for reference from the notebook.
+    # ==========================================
+
+    # stream = openai_client.chat.completions.create(
+    #     model="gpt-4.1-mini",
+    #     messages=[
+    #         {
+    #             "role": "system",
+    #             "content": BROCHURE_SYSTEM_PROMPT,
+    #         },
+    #         {
+    #             "role": "user",
+    #             "content": build_brochure_prompt(company_name, url),
+    #         },
+    #     ],
+    #     stream=True,
+    # )
+
+    # ==========================================
+    # Ollama + Llama 3.2 Version
+    # Active implementation.
+    # ==========================================
+
+    stream = ollama_client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": BROCHURE_SYSTEM_PROMPT,
+            },
+            {
+                "role": "user",
+                "content": build_brochure_prompt(company_name, url),
+            },
+        ],
+        stream=True,
+    )
+
+    response = ""
+
+    print("\n--- Company Brochure ---\n")
+
+    for chunk in stream:
+        content = chunk.choices[0].delta.content or ""
+
+        response += content
+
+        print(
+            content,
+            end="",
+            flush=True,
+        )
+
+    print("\n")
+
+    return response

--- a/community-contributions/company-brochure-project/src/links.py
+++ b/community-contributions/company-brochure-project/src/links.py
@@ -1,0 +1,66 @@
+"""
+links.py
+--------
+
+Responsible only for:
+
+* selecting the company links relevant to a brochure
+* building the link-selection user prompt (delegated to prompts.py)
+* calling the LLM to classify/select links
+* parsing and returning the resulting JSON
+
+No brochure-generation logic lives here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from llm import MODEL, ollama_client
+from prompts import LINK_SYSTEM_PROMPT, get_links_user_prompt
+from utils import parse_json_response
+
+
+def select_relevant_links(url: str) -> dict[str, Any]:
+    """
+    Ask the LLM to select the links on the given website that are most
+    relevant for building a company brochure.
+
+    :param url: Full URL of the company website to inspect.
+    :return: A dictionary of the form {"links": [{"type": ..., "url": ...}, ...]}.
+    """
+    print(f"Selecting relevant links for {url} by calling {MODEL}")
+
+    # ==========================================
+    # OpenAI / GPT Version - Original Code (kept for reference)
+    # ==========================================
+    #
+    # response = openai_client.chat.completions.create(
+    #     model=MODEL,
+    #     messages=[
+    #         {"role": "system", "content": LINK_SYSTEM_PROMPT},
+    #         {"role": "user", "content": get_links_user_prompt(url)}
+    #     ],
+    #     response_format={"type": "json_object"}
+    # )
+
+    # ==========================================
+    # Ollama + Llama 3.2 Version - active implementation
+    # ==========================================
+
+    response = ollama_client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": LINK_SYSTEM_PROMPT},
+            {"role": "user", "content": get_links_user_prompt(url)},
+        ],
+        response_format={"type": "json_object"},
+    )
+
+    result = response.choices[0].message.content
+
+    links = parse_json_response(result)
+
+    print(f"Found {len(links['links'])} relevant links")
+
+    return links

--- a/community-contributions/company-brochure-project/src/llm.py
+++ b/community-contributions/company-brochure-project/src/llm.py
@@ -1,0 +1,67 @@
+"""
+llm.py
+------
+
+Responsible only for setting up the LLM client used throughout the
+project: loading environment variables and initializing the
+OpenAI-compatible client pointed at a local Ollama server.
+
+No prompts, scraping, or brochure-generation logic lives here.
+"""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+# ==========================
+# Environment
+# ==========================
+
+# Load environment variables from a .env file, if present. Kept for parity
+# with the original notebook (e.g. in case OPENAI_API_KEY or other
+# environment-based configuration is needed later).
+load_dotenv(override=True)
+
+# ==========================
+# Model / Client configuration
+# ==========================
+
+# ==========================
+# OpenAI Version (Paid API) - kept for reference, not used by default
+# ==========================
+#
+# api_key = os.getenv('OPENAI_API_KEY')
+#
+# if api_key and api_key.startswith('sk-proj-') and len(api_key) > 10:
+#     print("API key looks good so far")
+# else:
+#     print("There might be a problem with your API key? Please visit the troubleshooting notebook!")
+#
+# MODEL = 'gpt-5-nano'
+# openai_client = OpenAI()
+
+# ==========================
+# Ollama Version (Free / Local) - active configuration
+# ==========================
+
+MODEL: str = "llama3.2"
+
+OLLAMA_BASE_URL: str = "http://localhost:11434/v1"
+OLLAMA_API_KEY: str = "ollama"
+
+# OpenAI-compatible client pointed at the local Ollama server.
+ollama_client: OpenAI = OpenAI(
+    base_url=OLLAMA_BASE_URL,
+    api_key=OLLAMA_API_KEY,
+)
+
+
+def get_client() -> OpenAI:
+    """
+    Return the initialized OpenAI-compatible client used to talk to the
+    local Ollama server.
+
+    :return: The configured OpenAI client instance.
+    """
+    return ollama_client

--- a/community-contributions/company-brochure-project/src/main.py
+++ b/community-contributions/company-brochure-project/src/main.py
@@ -1,0 +1,48 @@
+"""
+main.py
+-------
+
+Program entry point. Responsible only for:
+
+* user interaction (collecting company name and website URL)
+* calling the brochure-generation pipeline
+* printing / streaming the resulting brochure
+
+No scraping logic, prompt definitions, or LLM client setup lives here.
+"""
+
+from __future__ import annotations
+
+from brochure import stream_brochure
+
+
+def get_company_name() -> str:
+    """Prompt the user for the company name."""
+    return input("Enter the company name: ").strip()
+
+
+def get_company_url() -> str:
+    """Prompt the user for the company's website URL."""
+    return input(
+        "Enter the company website URL (e.g. https://example.com): "
+    ).strip()
+
+
+def main() -> None:
+    """
+    Collect the company name and website URL, then generate
+    and stream the company brochure.
+    """
+    company_name = get_company_name()
+    url = get_company_url()
+
+    print(
+        f"\nGenerating brochure for '{company_name}' "
+        f"({url}) using local Llama 3.2 via Ollama...\n"
+    )
+
+    stream_brochure(company_name, url)
+
+
+if __name__ == "__main__":
+    main()

--- a/community-contributions/company-brochure-project/src/prompts.py
+++ b/community-contributions/company-brochure-project/src/prompts.py
@@ -1,0 +1,162 @@
+"""
+prompts.py
+----------
+
+Central location for every prompt used in the project (system prompts and
+user-prompt builder functions). No API calls, scraping, or brochure
+assembly logic lives here — only prompt text and prompt construction.
+"""
+
+from __future__ import annotations
+
+from scraper import fetch_website_links
+
+# ==========================
+# Link-selection prompts
+# ==========================
+
+LINK_SYSTEM_PROMPT: str = """
+You are provided with a list of links found on a webpage.
+
+Your task is to select the links that are most relevant for creating a professional company brochure.
+
+Select pages such as:
+- About or Company
+- Products or Services
+- Careers or Jobs
+- Team or Leadership
+- Company History
+- Customers or Case Studies
+- Press or News
+- Important company information
+
+Ignore:
+- Terms of Service
+- Privacy Policy
+- Cookie Policy
+- Email links
+- Social media profiles
+- Unrelated external websites
+- Duplicate links
+- Navigation or anchor links
+
+IMPORTANT:
+- Only select URLs that appear in the provided list.
+- Never invent, guess, or modify a URL.
+- Do not create URLs that were not provided.
+- If there is no suitable page for a category, simply omit it.
+- Every selected link must have a valid non-empty URL.
+
+Respond only in JSON using this format:
+
+{
+    "links": [
+        {
+            "type": "about page",
+            "url": "https://example.com/about"
+        }
+    ]
+}
+"""
+
+
+def get_links_user_prompt(url: str) -> str:
+    """
+    Build the user prompt asking the LLM to select relevant links for the
+    given website, listing every link extracted from that page.
+
+    :param url: Full URL of the website to inspect.
+    :return: The complete user prompt text, including all discovered links.
+    """
+    user_prompt = f"""
+Here is the list of links extracted from the website: {url}
+
+Please identify which links are relevant for creating a professional company brochure.
+
+Select useful pages such as:
+- About or Company pages
+- Products or Services pages
+- Careers or Jobs pages
+- Team or Leadership pages
+- Company history
+- Customers or Case Studies
+- Other pages containing important company information
+
+Ignore:
+- Terms of Service
+- Privacy Policy
+- Cookie Policy
+- Email links
+- Social media profiles
+- Unrelated external websites
+- Duplicate links
+- Navigation or anchor links
+
+Return the selected links as valid JSON with the full HTTPS URL.
+
+Some links may be relative links, so convert them into complete HTTPS URLs using the website domain.
+
+Links:
+"""
+
+    links = fetch_website_links(url)
+    user_prompt += "\n".join(links)
+
+    return user_prompt
+
+
+# ==========================
+# Brochure-generation prompts
+# ==========================
+
+BROCHURE_SYSTEM_PROMPT: str = """
+You are an assistant that analyzes the contents of several relevant pages from a company website
+and creates a short, professional brochure about the company for prospective customers, investors, and recruits.
+
+Use only the information provided in the website content.
+Do not invent facts or make unsupported claims.
+
+Respond in Markdown without code blocks.
+
+Include, when available:
+- Company overview
+- Products or services
+- Company culture
+- Customers or use cases
+- Team or leadership
+- Careers and job opportunities
+- Important achievements or differentiators
+
+Keep the brochure clear, concise, professional, and engaging.
+"""
+
+
+def get_brochure_user_prompt(company_name: str, website_content: str) -> str:
+    """
+    Build the user prompt for brochure generation, given the company name
+    and the already-assembled website content (landing page + relevant
+    linked pages).
+
+    :param company_name: Name of the company the brochure is about.
+    :param website_content: Assembled text content from the company's
+        landing page and its relevant linked pages.
+    :return: The complete user prompt text to send to the LLM.
+    """
+    user_prompt = f"""
+You are looking at a company called: {company_name}
+
+Here are the contents of its landing page and other relevant pages.
+
+Use this information to build a short, professional company brochure
+in Markdown without code blocks.
+
+Use only the information provided below.
+Do not invent facts.
+
+Website content:
+
+"""
+
+    user_prompt += website_content
+
+    return user_prompt

--- a/community-contributions/company-brochure-project/src/scraper.py
+++ b/community-contributions/company-brochure-project/src/scraper.py
@@ -1,0 +1,94 @@
+"""
+scraper.py
+----------
+
+Responsible only for the raw web-scraping mechanics of the project:
+
+* issuing HTTP requests
+* parsing HTML with BeautifulSoup
+* cleaning page content (removing scripts, styles, images, forms/inputs)
+* extracting the title + body text of a page
+* extracting the list of links found on a page
+
+No LLM logic, prompt logic, or brochure-assembly logic lives here.
+"""
+
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+
+from utils import truncate_text
+
+# ==========================
+# Constants
+# ==========================
+
+# Standard browser-like headers so sites don't reject a "bot" user agent.
+REQUEST_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
+    )
+}
+
+# Sensible timeout (in seconds) so a hanging request never blocks forever.
+REQUEST_TIMEOUT_SECONDS: int = 15
+
+# Same truncation limit used in the original notebook/scraper.py.
+MAX_CONTENT_CHARACTERS: int = 2_000
+
+# Tags considered irrelevant to the textual content of a page.
+IRRELEVANT_TAGS: tuple[str, ...] = ("script", "style", "img", "input")
+
+DEFAULT_TITLE: str = "No title found"
+
+
+def fetch_website_contents(url: str) -> str:
+    """
+    Fetch a URL and return its cleaned title + body text.
+
+    Scripts, styles, images, and form inputs are stripped out before the
+    text is extracted. The result is truncated to MAX_CONTENT_CHARACTERS,
+    matching the original notebook behavior.
+
+    :param url: Full URL of the page to fetch.
+    :return: A string of the form "<title>\n\n<body text>", truncated.
+    """
+    response = requests.get(url, headers=REQUEST_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    title = soup.title.string if soup.title else DEFAULT_TITLE
+
+    if soup.body:
+        for irrelevant in soup.body(IRRELEVANT_TAGS):
+            irrelevant.decompose()
+        text = soup.body.get_text(separator="\n", strip=True)
+    else:
+        text = ""
+
+    contents = f"{title}\n\n{text}"
+    return truncate_text(contents, MAX_CONTENT_CHARACTERS)
+
+
+def fetch_website_links(url: str) -> list[str]:
+    """
+    Fetch a URL and return the list of href values found on the page.
+
+    Note: this re-fetches/re-parses the page independently of
+    fetch_website_contents. This mirrors the original (intentionally
+    simple) notebook implementation, which parses the page twice rather
+    than sharing a single BeautifulSoup object.
+
+    :param url: Full URL of the page to fetch.
+    :return: A list of non-empty href strings (may be relative or absolute).
+    """
+    response = requests.get(url, headers=REQUEST_HEADERS, timeout=REQUEST_TIMEOUT_SECONDS)
+    response.raise_for_status()
+
+    soup = BeautifulSoup(response.content, "html.parser")
+    links = [link.get("href") for link in soup.find_all("a")]
+
+    return [link for link in links if link]

--- a/community-contributions/company-brochure-project/src/utils.py
+++ b/community-contributions/company-brochure-project/src/utils.py
@@ -1,0 +1,40 @@
+"""
+utils.py
+--------
+
+Small, reusable helper functions shared across the project. Only helpers
+that are actually used elsewhere live here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def truncate_text(text: str, max_characters: int) -> str:
+    """
+    Truncate text to a maximum number of characters.
+
+    Used both when cleaning scraped page content and when assembling the
+    final brochure prompt, so the limit logic lives in one place.
+
+    :param text: The text to truncate.
+    :param max_characters: Maximum number of characters to keep.
+    :return: The truncated text (unchanged if already within the limit).
+    """
+    return text[:max_characters]
+
+
+def parse_json_response(raw_response: str) -> dict[str, Any]:
+    """
+    Parse a JSON string returned by the LLM into a Python dictionary.
+
+    Centralizes JSON parsing so error handling / behavior stays consistent
+    everywhere the project needs to interpret a structured LLM response.
+
+    :param raw_response: The raw JSON string returned by the LLM.
+    :return: The parsed dictionary.
+    :raises json.JSONDecodeError: If the response is not valid JSON.
+    """
+    return json.loads(raw_response)


### PR DESCRIPTION
Refactored version of the day5.ipynb notebook from Week 1 into a 
production-style Python project. Scrapes a company website, uses 
a local Llama 3.2 model (via Ollama) to select relevant pages, 
then generates a Markdown brochure with streaming output.

- 100% local/free (no paid API key needed)
- Modular structure (scraper, links, prompts, llm, brochure, utils)
- See README for full details