### PR TITLE
Add Week 1 email summarizer and Playwright openai.com scraper

### DIFF
--- a/week1/community-contributions/hitesh/day1.ipynb
+++ b/week1/community-contributions/hitesh/day1.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# Day 1 exercise: Email summarizer\n",
+    "\n",
+    "Hands-on variation of the Week 1 website summarizer.\n",
+    "\n",
+    "Write a **system prompt** and a **user prompt**, then call the OpenAI Chat Completions API to:\n",
+    "\n",
+    "1. Summarize an email\n",
+    "2. Suggest a short, scannable subject line\n",
+    "\n",
+    "Select the repo `.venv` kernel (same as `week1/day1.ipynb`) before running.\n",
+    "\n",
+    "The JS-site scraper for openai.com is in `openai_summarizer.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "connect-md",
+   "metadata": {},
+   "source": [
+    "## Connect to OpenAI\n",
+    "\n",
+    "Load `OPENAI_API_KEY` from the project `.env` (repo root). If this cell fails, use the troubleshooting notebook in `setup/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load-env",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "api_key = os.getenv(\"OPENAI_API_KEY\")\n",
+    "\n",
+    "if not api_key:\n",
+    "    print(\"No API key was found — check your .env and the troubleshooting notebook.\")\n",
+    "elif not api_key.startswith(\"sk-proj-\"):\n",
+    "    print(\"An API key was found, but it doesn't start sk-proj-; please check you're using the right key.\")\n",
+    "elif api_key.strip() != api_key:\n",
+    "    print(\"An API key was found, but it looks like it might have space or tab characters at the start or end.\")\n",
+    "else:\n",
+    "    print(\"API key found and looks good so far!\")\n",
+    "\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "email-md",
+   "metadata": {},
+   "source": [
+    "## The email to summarize\n",
+    "\n",
+    "Paste any email into `email` and re-run the cells below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sample-email",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "email = \"\"\"\n",
+    "From: Manish Kumar <manish@acme.com>\n",
+    "To: Hitesh Kumar <hitesh@acme.com>\n",
+    "Date: Mon, 16 Aug 2026 10:12:00 +0530\n",
+    "\n",
+    "Hi Hitesh,\n",
+    "\n",
+    "Quick update on the Q3 launch. Engineering is still waiting on legal review of the\n",
+    "privacy copy, so we cannot ship the onboarding flow on Thursday as planned.\n",
+    "\n",
+    "Can you:\n",
+    "1. Confirm whether we can use last quarter's privacy wording as a stopgap\n",
+    "2. Join a 20-minute call tomorrow at 3pm IST with Legal and Product\n",
+    "3. Send a one-paragraph status to leadership by EOD Tuesday\n",
+    "\n",
+    "If we miss Thursday, the fallback is next Monday. Please flag if that's a problem\n",
+    "for the marketing campaign.\n",
+    "\n",
+    "Thanks,\n",
+    "Priya\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "prompts-md",
+   "metadata": {},
+   "source": [
+    "## Types of prompts\n",
+    "\n",
+    "- **System prompt** — who the model is, and how it should format the answer\n",
+    "- **User prompt** — the actual email to work on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "system-prompt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are an email assistant for a busy professional.\n",
+    "\n",
+    "Given an email, you must:\n",
+    "- Write a concise summary (3–6 bullets): purpose, asks, deadlines, decisions needed\n",
+    "- Suggest one short subject line (max 8 words), specific and scannable\n",
+    "- Call out urgency if a deadline or meeting is mentioned\n",
+    "\n",
+    "Respond in markdown with exactly these two sections:\n",
+    "\n",
+    "## Subject\n",
+    "<one line, no quotes>\n",
+    "\n",
+    "## Summary\n",
+    "- bullet\n",
+    "- bullet\n",
+    "\n",
+    "Do not wrap the markdown in a code block — respond with the markdown only.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "user-prompt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def user_prompt_for(email_text: str) -> str:\n",
+    "    return f\"\"\"\n",
+    "Please summarize this email and suggest a subject line.\n",
+    "\n",
+    "Email:\n",
+    "{email_text}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "messages-md",
+   "metadata": {},
+   "source": [
+    "## Messages\n",
+    "\n",
+    "```python\n",
+    "[\n",
+    "    {\"role\": \"system\", \"content\": \"system message goes here\"},\n",
+    "    {\"role\": \"user\", \"content\": \"user message goes here\"}\n",
+    "]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "messages-for",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def messages_for(email_text: str):\n",
+    "    return [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt_for(email_text)},\n",
+    "    ]\n",
+    "\n",
+    "messages_for(email)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "api-md",
+   "metadata": {},
+   "source": [
+    "## Call Chat Completions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "summarize",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def summarize_email(email_text: str) -> str:\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model=\"gpt-4.1-mini\",\n",
+    "        messages=messages_for(email_text),\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "result = summarize_email(email)\n",
+    "display(Markdown(result))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "try-another-md",
+   "metadata": {},
+   "source": [
+    "## Try another email"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "second-email",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "another_email = \"\"\"\n",
+    "From: Manish Kumar <manish@vendor.io>\n",
+    "To: Hitesh Kumar <hitesh@acme.com>\n",
+    "Subject: Invoice 1842\n",
+    "\n",
+    "Hi Hitesh,\n",
+    "\n",
+    "Invoice 1842 for the August GPU hours ($1,240) is attached. Payment is due\n",
+    "in 14 days. If you need the usage breakdown split by project, reply and I\n",
+    "will send it.\n",
+    "\n",
+    "Alex\n",
+    "\"\"\"\n",
+    "\n",
+    "display(Markdown(summarize_email(another_email)))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week1/community-contributions/hitesh/openai_summarizer.ipynb
+++ b/week1/community-contributions/hitesh/openai_summarizer.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "title",
+   "metadata": {},
+   "source": [
+    "# Day 1 extra: summarize openai.com\n",
+    "\n",
+    "`display_summary(\"https://openai.com\")` fails with `week1/scraper.py` because the site is a JavaScript app. This notebook uses Playwright (a real Chromium) instead of `requests`.\n",
+    "\n",
+    "One-time setup in the repo `.venv`:\n",
+    "\n",
+    "```bash\n",
+    "uv pip install playwright\n",
+    "playwright install chromium\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "from scraper_playwright import fetch_website_contents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "client",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "load_dotenv(override=True)\n",
+    "openai = OpenAI()\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "You are a snarky assistant that analyzes the contents of a website,\n",
+    "and provides a short, snarky, humorous summary, ignoring text that might be navigation related.\n",
+    "Respond in markdown. Do not wrap the markdown in a code block - respond just with the markdown.\n",
+    "\"\"\"\n",
+    "\n",
+    "user_prompt_prefix = \"\"\"\n",
+    "Here are the contents of a website.\n",
+    "Provide a short summary of this website.\n",
+    "If it includes news or announcements, then summarize these too.\n",
+    "\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "messages",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def messages_for(website: str):\n",
+    "    return [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt_prefix + website},\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "async def summarize(url: str) -> str:\n",
+    "    website = await fetch_website_contents(url)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model=\"gpt-4.1-mini\",\n",
+    "        messages=messages_for(website),\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "async def display_summary(url: str):\n",
+    "    display(Markdown(await summarize(url)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "preview-md",
+   "metadata": {},
+   "source": [
+    "Preview the rendered text (first 500 characters) so you can see Playwright got past the empty `requests` scrape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "preview",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preview = await fetch_website_contents(\"https://openai.com\")\n",
+    "print(preview[:500])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await display_summary(\"https://openai.com\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c2249dc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week1/community-contributions/hitesh/scraper_playwright.py
+++ b/week1/community-contributions/hitesh/scraper_playwright.py
@@ -1,0 +1,66 @@
+"""Fetch page title and text after JavaScript has rendered (Playwright).
+
+Same idea as week1/scraper.py, but requests + BeautifulSoup cannot see
+React sites such as https://openai.com. Playwright runs Chromium instead.
+
+First time: `uv pip install playwright` then `playwright install chromium`.
+"""
+
+from bs4 import BeautifulSoup
+from playwright.async_api import async_playwright
+
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/120.0.0.0 Safari/537.36"
+)
+
+MAX_CHARS = 2_000
+
+
+def _text_from_html(html: str) -> tuple[str, str]:
+    soup = BeautifulSoup(html, "html.parser")
+    title = soup.title.string.strip() if soup.title and soup.title.string else "No title found"
+    if soup.body:
+        for tag in soup.body(["script", "style", "img", "input", "nav", "footer"]):
+            tag.decompose()
+        text = soup.body.get_text(separator="\n", strip=True)
+    else:
+        text = ""
+    return title, text
+
+
+async def fetch_website_contents(url: str, max_chars: int = MAX_CHARS) -> str:
+    """Return title plus visible text, truncated like scraper.py."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        try:
+            context = await browser.new_context(user_agent=USER_AGENT)
+            page = await context.new_page()
+            # networkidle often hangs on analytics-heavy sites; wait for DOM then JS paint
+            await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+            await page.wait_for_timeout(2_000)
+            html = await page.content()
+        finally:
+            await browser.close()
+
+    title, text = _text_from_html(html)
+    return (title + "\n\n" + text)[:max_chars]
+
+
+async def fetch_website_links(url: str) -> list[str]:
+    """Return hrefs after JavaScript has run."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        try:
+            context = await browser.new_context(user_agent=USER_AGENT)
+            page = await context.new_page()
+            await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+            await page.wait_for_timeout(2_000)
+            hrefs = await page.eval_on_selector_all(
+                "a[href]",
+                "els => els.map(el => el.getAttribute('href'))",
+            )
+        finally:
+            await browser.close()
+    return [href for href in hrefs if href]


### PR DESCRIPTION
## Summary
Week 1 community contribution under `week1/community-contributions/hitesh/`.

- Email summarizer: system/user prompts and Chat Completions to summarize an email and suggest a short subject line
- openai.com summarizer: Playwright scraper (Chromium) so JS-rendered pages work, then the same Day 1 summarize flow

## Test plan
- Select the repo `.venv` kernel
- Run `week1/community-contributions/hitesh/day1.ipynb`
- One-time: `uv pip install playwright` then `uv run playwright install chromium`
- Run `week1/community-contributions/hitesh/openai_summarizer.ipynb` against https://openai.com