### PR TITLE
contributions: youtube shorts ideas generator from transcript

### DIFF
--- a/community-contributions/yt-shorts-ideas-by-bearnithi/shorts.ipynb
+++ b/community-contributions/yt-shorts-ideas-by-bearnithi/shorts.ipynb
@@ -2,48 +2,80 @@
   "cells": [
     {
       "cell_type": "markdown",
-      "id": "d89214ac",
       "metadata": {},
       "source": [
-        "### Youtube Shorts Ideas from a Long form Youtube Video Transcript\n",
+        "# YouTube Shorts Ideas from a Long-Form Video Transcript\n",
         "\n",
-        "This project gives you list of youtube shorts you can make out of a youtube video transcript. All you need to do is to just post your youtube video url into it.\n",
+        "Turn one long YouTube video into **5 Shorts ideas**. Paste a video URL, this notebook fetches the captions, and an LLM suggests clips you could cut — each idea includes a title, a short description, and start/end times from the original transcript.\n",
         "\n",
-        "Note: this is only for learning purpose and personal use only. You can't commercialize it as youtube blocks specific ips after deployment like aws, azure etc"
-      ]
+        "**Learning / personal use only.** YouTube often blocks caption requests from cloud IPs (AWS, Azure, etc.), so this is meant to run locally, not as a commercial product.\n",
+        "\n",
+        "## What you need before you start\n",
+        "\n",
+        "1. **OpenAI API key** in your environment as `OPENAI_API_KEY` (same setup as the rest of this course).\n",
+        "2. A YouTube video that **has captions**.\n",
+        "3. A URL in this shape: `https://www.youtube.com/watch?v=VIDEO_ID`  \n",
+        "   (The code only reads the `v=` query parameter — not `youtu.be` or `/shorts/` links.)\n",
+        "\n",
+        "## How to run\n",
+        "\n",
+        "1. Run **every cell from top to bottom** (do not skip).\n",
+        "2. In **Step 3**, you can replace the sample `video_url` with your own `watch?v=` link, then re-run from that cell onward.\n",
+        "3. The last cell prints the ideas as formatted JSON.\n",
+        "\n",
+        "## What each step does\n",
+        "\n",
+        "| Step | What happens |\n",
+        "|------|----------------|\n",
+        "| 1 | Installs `youtube-transcript-api` |\n",
+        "| 2 | Loads OpenAI + helper functions to pull the transcript |\n",
+        "| 3 | Fetches captions for the URL you set |\n",
+        "| 4 | Builds the system and user prompts |\n",
+        "| 5 | Calls the model and displays 5 Shorts ideas |\n",
+        "\n",
+        "If a cell fails, check: API key is set, the video has captions, and the URL contains `v=`."
+      ],
+      "id": "d89214ac"
     },
     {
       "cell_type": "markdown",
-      "id": "3bc763c5",
       "metadata": {},
       "source": [
-        "### Step 1 - Install Youtube Transacript API package\n"
-      ]
+        "## Step 1 — Install the YouTube transcript package\n",
+        "\n",
+        "Run this once per environment. It installs `youtube-transcript-api`, which downloads the video’s captions. The OpenAI Python package is assumed to already be available from the course setup.\n"
+      ],
+      "id": "3bc763c5"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "68b0cb70",
       "metadata": {},
-      "outputs": [],
       "source": [
         "%pip install youtube-transcript-api"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "68b0cb70"
     },
     {
       "cell_type": "markdown",
-      "id": "a0a8d060",
       "metadata": {},
       "source": [
-        "### Step 2 - Define Imports & functions to extract transcript"
-      ]
+        "## Step 2 — Imports and transcript helpers\n",
+        "\n",
+        "This cell:\n",
+        "\n",
+        "- Creates an OpenAI client from `OPENAI_API_KEY`\n",
+        "- Defines `get_video_id()` — takes the ID after `v=` in the URL\n",
+        "- Defines `get_transcript()` — fetches captions for that ID\n",
+        "\n",
+        "Run it after Step 1 so the functions exist before you fetch a video."
+      ],
+      "id": "a0a8d060"
     },
     {
       "cell_type": "code",
-      "execution_count": 40,
-      "id": "6248992c",
       "metadata": {},
-      "outputs": [],
       "source": [
         "from openai import OpenAI\n",
         "import os\n",
@@ -68,49 +100,55 @@
         "    video_id = url.split(\"v=\")[1]\n",
         "    return video_id\n",
         "\n"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "6248992c"
     },
     {
       "cell_type": "markdown",
-      "id": "a1827175",
       "metadata": {},
       "source": [
-        "### Step 3 - pass the video url to the function"
-      ]
+        "## Step 3 — Fetch the transcript\n",
+        "\n",
+        "Set `video_url` to a captioned YouTube video, then run the cell. A sample URL is already filled in.\n",
+        "\n",
+        "To try your own video: paste a `https://www.youtube.com/watch?v=...` link, run this cell again, then continue with Steps 4 and 5.\n",
+        "\n",
+        "If this fails, the video may have no captions, or the URL may not include `v=`."
+      ],
+      "id": "a1827175"
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
-      "id": "fe5dfa5a",
       "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "qp0HIF3SfI4\n"
-          ]
-        }
-      ],
       "source": [
         "video_url = \"https://www.youtube.com/watch?v=qp0HIF3SfI4\"\n",
         "transcriptJSON = get_transcript(video_url).to_raw_data()"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "fe5dfa5a"
     },
     {
       "cell_type": "markdown",
-      "id": "f40ec139",
       "metadata": {},
       "source": [
-        "### Step 4 - Define System Prompt & User Prompt"
-      ]
+        "## Step 4 — System prompt and user prompt\n",
+        "\n",
+        "The **system prompt** tells the model to return **5 Shorts ideas** as JSON. Each idea should include:\n",
+        "\n",
+        "- `idea` — a short title\n",
+        "- `description` — what the Short would cover\n",
+        "- `original_transcript_start_time` / `original_transcript_end_time` — where that moment sits in the long video\n",
+        "\n",
+        "The **user prompt** is the transcript from Step 3. Run this cell so both prompts are defined before the API call."
+      ],
+      "id": "f40ec139"
     },
     {
       "cell_type": "code",
-      "execution_count": 42,
-      "id": "a2eab15b",
       "metadata": {},
-      "outputs": [],
       "source": [
         "system_prompt = \"\"\"\n",
         "You are a helpful assistant that can help me generate ideas for YouTube Shorts.\n",
@@ -139,73 +177,26 @@
         "    Here is the transcript of the video:\n",
         "    {transcriptJSON}\n",
         "\"\"\""
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "a2eab15b"
     },
     {
       "cell_type": "markdown",
-      "id": "98dc6f9e",
       "metadata": {},
       "source": [
-        "### Final Step - Call AI Model with the prompts & transcript to get the short ideas"
-      ]
+        "## Step 5 — Call the model and show the Shorts ideas\n",
+        "\n",
+        "This sends the prompts to OpenAI and prints the JSON in Markdown.\n",
+        "\n",
+        "This is the cell that spends API credits. After it finishes, you should see five ideas with timestamps you can use to jump back into the original video."
+      ],
+      "id": "98dc6f9e"
     },
     {
       "cell_type": "code",
-      "execution_count": null,
-      "id": "60f2bfce",
       "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/markdown": [
-              "\n",
-              "# YouTube Shorts Ideas\n",
-              "\n",
-              "```json\n",
-              "{\n",
-              "    \"shorts\": [\n",
-              "        {\n",
-              "            \"idea\": \"Flip Your Pitch: Apple\\u2019s 'Start With Why' in 30 Seconds\",\n",
-              "            \"description\": \"Split-screen: top shows a boring 'We make great computers...' pitch; bottom shows Apple's real pitch 'We believe in challenging the status quo...' End with on-screen: 'People don\\u2019t buy what you do; they buy why you do it.'\",\n",
-              "            \"original_transcript_start_time\": 244.257,\n",
-              "            \"original_transcript_end_time\": 277.59\n",
-              "        },\n",
-              "        {\n",
-              "            \"idea\": \"The Golden Circle Explained (Why > How > What)\",\n",
-              "            \"description\": \"Fast sketch of three concentric circles labeled Why, How, What while the voiceover defines each and asks: 'Why does your organization exist? Why should anyone care?' Simple doodle + captions.\",\n",
-              "            \"original_transcript_start_time\": 131.557,\n",
-              "            \"original_transcript_end_time\": 175.657\n",
-              "        },\n",
-              "        {\n",
-              "            \"idea\": \"The Biology of Belief: Why 'It Doesn\\u2019t Feel Right'\",\n",
-              "            \"description\": \"Use a simple brain graphic: highlight neocortex (facts/language) vs limbic brain (feelings/decisions, no language). On-screen text: 'Decisions first. Reasons second.'\",\n",
-              "            \"original_transcript_start_time\": 360.257,\n",
-              "            \"original_transcript_end_time\": 414.623\n",
-              "        },\n",
-              "        {\n",
-              "            \"idea\": \"Wright Brothers vs. Langley: Purpose Beats Resources\",\n",
-              "            \"description\": \"Rapid cuts of 'no money, no degrees, no press' vs 'Harvard, funding, NYT'. Overlay: 'Belief > Budget.' End with 'They worked with blood, sweat, and tears.'\",\n",
-              "            \"original_transcript_start_time\": 568.257,\n",
-              "            \"original_transcript_end_time\": 612.257\n",
-              "        },\n",
-              "        {\n",
-              "            \"idea\": \"The Tipping Point: Innovators to Early Majority\",\n",
-              "            \"description\": \"Animate a simple bell curve labeling innovators, early adopters, and the 15\\u201318% tipping point. On-screen: 'Cross the chasm before scaling.'\",\n",
-              "            \"original_transcript_start_time\": 667.657,\n",
-              "            \"original_transcript_end_time\": 709.257\n",
-              "        }\n",
-              "    ]\n",
-              "}\n",
-              "```\n"
-            ],
-            "text/plain": [
-              "<IPython.core.display.Markdown object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
       "source": [
         "\n",
         "\n",
@@ -232,7 +223,10 @@
         "\"\"\"\n",
         "\n",
         "display(Markdown(markdown_content))\n"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "60f2bfce"
     }
   ],
   "metadata": {

--- a/community-contributions/yt-shorts-ideas-by-bearnithi/shorts.ipynb
+++ b/community-contributions/yt-shorts-ideas-by-bearnithi/shorts.ipynb
@@ -1,0 +1,259 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "d89214ac",
+      "metadata": {},
+      "source": [
+        "### Youtube Shorts Ideas from a Long form Youtube Video Transcript\n",
+        "\n",
+        "This project gives you list of youtube shorts you can make out of a youtube video transcript. All you need to do is to just post your youtube video url into it.\n",
+        "\n",
+        "Note: this is only for learning purpose and personal use only. You can't commercialize it as youtube blocks specific ips after deployment like aws, azure etc"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "3bc763c5",
+      "metadata": {},
+      "source": [
+        "### Step 1 - Install Youtube Transacript API package\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "68b0cb70",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install youtube-transcript-api"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a0a8d060",
+      "metadata": {},
+      "source": [
+        "### Step 2 - Define Imports & functions to extract transcript"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 40,
+      "id": "6248992c",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from openai import OpenAI\n",
+        "import os\n",
+        "import json\n",
+        "from IPython.display import Markdown\n",
+        "from youtube_transcript_api import YouTubeTranscriptApi\n",
+        "\n",
+        "client = OpenAI(api_key=os.getenv(\"OPENAI_API_KEY\"))\n",
+        "\n",
+        "def get_transcript(url):\n",
+        "    try:\n",
+        "        video_id = get_video_id(url)\n",
+        "        print(video_id)\n",
+        "        transcript = YouTubeTranscriptApi().fetch(video_id)\n",
+        "        return transcript\n",
+        "    except Exception as e:\n",
+        "        print(f\"Error getting transcript for video {video_id}: {e}\")\n",
+        "        return None\n",
+        "\n",
+        "\n",
+        "def get_video_id(url):\n",
+        "    video_id = url.split(\"v=\")[1]\n",
+        "    return video_id\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "a1827175",
+      "metadata": {},
+      "source": [
+        "### Step 3 - pass the video url to the function"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 41,
+      "id": "fe5dfa5a",
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "qp0HIF3SfI4\n"
+          ]
+        }
+      ],
+      "source": [
+        "video_url = \"https://www.youtube.com/watch?v=qp0HIF3SfI4\"\n",
+        "transcriptJSON = get_transcript(video_url).to_raw_data()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "f40ec139",
+      "metadata": {},
+      "source": [
+        "### Step 4 - Define System Prompt & User Prompt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 42,
+      "id": "a2eab15b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "system_prompt = \"\"\"\n",
+        "You are a helpful assistant that can help me generate ideas for YouTube Shorts.\n",
+        "Given you get a youtube video transcript, you should carefully analyze the transcript and generate ideas for YouTube Shorts.\n",
+        "You should generate 5 ideas for YouTube Shorts based on the transcript.\n",
+        "\n",
+        "\n",
+        "The ideas should be unique and creative.\n",
+        "The ideas should be relevant to the transcript.\n",
+        "The ideas should be engaging and interesting to the audience.\n",
+        "The ideas should be easy to understand and implement.\n",
+        "\n",
+        "The output should be a json array of strings, where each string is an idea for a YouTube Short.\n",
+        "`[{\n",
+        "    \"idea\": \"string\",\n",
+        "    \"description\": \"string\",\n",
+        "    \"original_transcript_start_time\": \"number\",\n",
+        "    \"original_transcript_end_time\": \"number\"\n",
+        "}]`\n",
+        "\n",
+        "You should only response with the json array\n",
+        "\n",
+        "\"\"\"\n",
+        "\n",
+        "user_prompt = f\"\"\"\n",
+        "    Here is the transcript of the video:\n",
+        "    {transcriptJSON}\n",
+        "\"\"\""
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "98dc6f9e",
+      "metadata": {},
+      "source": [
+        "### Final Step - Call AI Model with the prompts & transcript to get the short ideas"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "60f2bfce",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/markdown": [
+              "\n",
+              "# YouTube Shorts Ideas\n",
+              "\n",
+              "```json\n",
+              "{\n",
+              "    \"shorts\": [\n",
+              "        {\n",
+              "            \"idea\": \"Flip Your Pitch: Apple\\u2019s 'Start With Why' in 30 Seconds\",\n",
+              "            \"description\": \"Split-screen: top shows a boring 'We make great computers...' pitch; bottom shows Apple's real pitch 'We believe in challenging the status quo...' End with on-screen: 'People don\\u2019t buy what you do; they buy why you do it.'\",\n",
+              "            \"original_transcript_start_time\": 244.257,\n",
+              "            \"original_transcript_end_time\": 277.59\n",
+              "        },\n",
+              "        {\n",
+              "            \"idea\": \"The Golden Circle Explained (Why > How > What)\",\n",
+              "            \"description\": \"Fast sketch of three concentric circles labeled Why, How, What while the voiceover defines each and asks: 'Why does your organization exist? Why should anyone care?' Simple doodle + captions.\",\n",
+              "            \"original_transcript_start_time\": 131.557,\n",
+              "            \"original_transcript_end_time\": 175.657\n",
+              "        },\n",
+              "        {\n",
+              "            \"idea\": \"The Biology of Belief: Why 'It Doesn\\u2019t Feel Right'\",\n",
+              "            \"description\": \"Use a simple brain graphic: highlight neocortex (facts/language) vs limbic brain (feelings/decisions, no language). On-screen text: 'Decisions first. Reasons second.'\",\n",
+              "            \"original_transcript_start_time\": 360.257,\n",
+              "            \"original_transcript_end_time\": 414.623\n",
+              "        },\n",
+              "        {\n",
+              "            \"idea\": \"Wright Brothers vs. Langley: Purpose Beats Resources\",\n",
+              "            \"description\": \"Rapid cuts of 'no money, no degrees, no press' vs 'Harvard, funding, NYT'. Overlay: 'Belief > Budget.' End with 'They worked with blood, sweat, and tears.'\",\n",
+              "            \"original_transcript_start_time\": 568.257,\n",
+              "            \"original_transcript_end_time\": 612.257\n",
+              "        },\n",
+              "        {\n",
+              "            \"idea\": \"The Tipping Point: Innovators to Early Majority\",\n",
+              "            \"description\": \"Animate a simple bell curve labeling innovators, early adopters, and the 15\\u201318% tipping point. On-screen: 'Cross the chasm before scaling.'\",\n",
+              "            \"original_transcript_start_time\": 667.657,\n",
+              "            \"original_transcript_end_time\": 709.257\n",
+              "        }\n",
+              "    ]\n",
+              "}\n",
+              "```\n"
+            ],
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=\"gpt-5\",\n",
+        "    messages=[\n",
+        "        {\"role\": \"system\", \"content\": system_prompt}, \n",
+        "        {\"role\": \"user\", \"content\": user_prompt}\n",
+        "    ],\n",
+        "    response_format={\"type\": \"json_object\"},\n",
+        ")\n",
+        "\n",
+        "shortsJSON = response.choices[0].message.content\n",
+        "\n",
+        "# format the json to display in a readable format in a Markdown\n",
+        "shortsJSON = json.loads(shortsJSON)\n",
+        "\n",
+        "markdown_content = f\"\"\"\n",
+        "# YouTube Shorts Ideas\n",
+        "\n",
+        "```json\n",
+        "{json.dumps(shortsJSON, indent=4)}\n",
+        "```\n",
+        "\"\"\"\n",
+        "\n",
+        "display(Markdown(markdown_content))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12.14"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a Week 1–style community notebook that turns a long-form YouTube video into Shorts ideas.

Paste a video URL; the notebook pulls the transcript with `youtube-transcript-api`, then asks OpenAI (`gpt-5`) for five Shorts concepts. Each idea includes a description and start/end times from the original transcript so you can jump to the clip.

## What it does

1. Install `youtube-transcript-api`
2. Parse the video ID from a `watch?v=` URL and fetch the transcript
3. Send the transcript with a system prompt that asks for **5 unique, relevant Shorts ideas** as JSON
4. Render the model’s JSON as Markdown

Expected shape per idea:

- `idea`
- `description`
- `original_transcript_start_time`
- `original_transcript_end_time`

## How to run

1. Set `OPENAI_API_KEY` in the environment
2. Open `community-contributions/yt-shorts-ideas-by-bearnithi/shorts.ipynb`
3. Run all cells (installs the transcript package)
4. Optional: change `video_url` in Step 3 to another `https://www.youtube.com/watch?v=...` link