### PR TITLE
Week 1 Day 1: Playwright web scraper for JavaScript-rendered sites

### DIFF
--- a/week1/community-contributions/slavapa/README.md
+++ b/week1/community-contributions/slavapa/README.md
@@ -1,0 +1,26 @@
+# Week 1 Day 1 — Playwright Web Scraper Exercise
+
+Playwright-enhanced scraper for JavaScript-rendered sites.
+
+**Sites tested:** kabbalahmedia.info, michaellaitman.com, kabuconnect.com
+
+## Setup
+
+```bash
+uv pip install playwright
+python -m playwright install chromium
+```
+
+Or: `uv pip install -r requirements.txt && python -m playwright install chromium`
+
+## Files
+
+- `scraper_playwright.py` — drop-in replacement for `week1/scraper.py` with Playwright fallback
+- `day1_playwright_exercise.ipynb` — summarizer demo using the three exercise sites
+
+## Usage in a notebook
+
+```python
+from scraper_playwright import fetch_website_contents
+content = fetch_website_contents("https://kabbalahmedia.info/en/")
+```

--- a/week1/community-contributions/slavapa/day1_playwright_exercise.ipynb
+++ b/week1/community-contributions/slavapa/day1_playwright_exercise.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "c3e02d63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Week 1 Day 1 — Extra Exercise: Playwright Web Scraper\n",
+    "\n",
+    "**Author:** slavapa\n",
+    "\n",
+    "The standard `scraper.py` uses `requests` + BeautifulSoup, which fails on JavaScript-rendered sites (e.g. OpenAI.com, Kabbalah Media).\n",
+    "\n",
+    "This notebook uses a **Playwright fallback** scraper and summarizes three exercise sites:\n",
+    "\n",
+    "- https://kabbalahmedia.info/en/\n",
+    "- https://www.michaellaitman.com/\n",
+    "- https://kabuconnect.com/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "784b3cef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "sys.path.insert(0, os.path.dirname(os.path.abspath(\"__file__\")))\n",
+    "from scraper_playwright import fetch_website_contents\n",
+    "\n",
+    "load_dotenv(override=True)\n",
+    "openai = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "d834cfd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Compare: basic requests vs Playwright\n",
+    "\n",
+    "Kabbalah Media is a JavaScript-rendered site — the basic scraper returns almost nothing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7aae6275",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(0, \"../../\")\n",
+    "from scraper import fetch_website_contents as fetch_basic\n",
+    "\n",
+    "url = \"https://kabbalahmedia.info/en/\"\n",
+    "basic = fetch_basic(url)\n",
+    "playwright = fetch_website_contents(url)\n",
+    "\n",
+    "print(f\"Basic scraper:      {len(basic)} chars\")\n",
+    "print(basic[:200])\n",
+    "print()\n",
+    "print(f\"Playwright scraper: {len(playwright)} chars\")\n",
+    "print(playwright[:500])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "id": "263baf4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Summarize all three exercise sites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f25c738e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EXERCISE_SITES = [\n",
+    "    \"https://kabbalahmedia.info/en/\",\n",
+    "    \"https://www.michaellaitman.com/\",\n",
+    "    \"https://kabuconnect.com/\",\n",
+    "]\n",
+    "\n",
+    "system_prompt = \"\"\"\n",
+    "You are a helpful assistant that analyzes website contents and provides a concise summary.\n",
+    "Ignore navigation menus, footers, and cookie banners.\n",
+    "Respond in markdown. Do not wrap the markdown in a code block.\n",
+    "\"\"\"\n",
+    "\n",
+    "user_prompt_prefix = \"\"\"\n",
+    "Here are the contents of a website.\n",
+    "Provide a short summary of this website.\n",
+    "If it includes news or announcements, summarize these too.\n",
+    "\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "def messages_for(website: str) -> list[dict]:\n",
+    "    return [\n",
+    "        {\"role\": \"system\", \"content\": system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": user_prompt_prefix + website},\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "def summarize(url: str) -> str:\n",
+    "    website = fetch_website_contents(url)\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model=\"gpt-4.1-mini\",\n",
+    "        messages=messages_for(website),\n",
+    "    )\n",
+    "    return response.choices[0].message.content\n",
+    "\n",
+    "\n",
+    "def display_summary(url: str) -> None:\n",
+    "    print(f\"### {url}\\n\")\n",
+    "    display(Markdown(summarize(url)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d422e66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for site in EXERCISE_SITES:\n",
+    "    display_summary(site)\n",
+    "    print(\"\\n---\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week1/community-contributions/slavapa/requirements.txt
+++ b/week1/community-contributions/slavapa/requirements.txt
@@ -1,0 +1,1 @@
+playwright>=1.40.0

--- a/week1/community-contributions/slavapa/scraper_playwright.py
+++ b/week1/community-contributions/slavapa/scraper_playwright.py
@@ -1,0 +1,129 @@
+"""
+Playwright-enhanced website scraper for JavaScript-rendered pages.
+
+Week 1 Day 1 extra exercise — slavapa contribution.
+Falls back to requests + BeautifulSoup first; uses Playwright when content is sparse.
+Works in plain Python scripts and Jupyter notebooks (including on Windows).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+
+import requests
+from bs4 import BeautifulSoup
+from playwright.async_api import async_playwright
+
+if sys.platform.startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"
+    )
+}
+
+MIN_TEXT_LENGTH = 500
+CHAR_LIMIT = 2_000
+
+
+def _clean_text_from_soup(soup: BeautifulSoup) -> tuple[str, str]:
+    title = soup.title.string.strip() if soup.title and soup.title.string else "No title found"
+    if soup.body:
+        for irrelevant in soup.body(["script", "style", "img", "input"]):
+            irrelevant.decompose()
+        text = soup.body.get_text(separator="\n", strip=True)
+    else:
+        text = ""
+    return title, text
+
+
+def _fetch_with_requests(url: str, timeout: int = 15) -> BeautifulSoup:
+    response = requests.get(url, headers=HEADERS, timeout=timeout)
+    response.raise_for_status()
+    return BeautifulSoup(response.content, "html.parser")
+
+
+async def _fetch_with_playwright_async(url: str, timeout_ms: int = 60_000) -> BeautifulSoup:
+    async with async_playwright() as playwright:
+        browser = await playwright.chromium.launch(headless=True)
+        page = await browser.new_page(user_agent=HEADERS["User-Agent"])
+        try:
+            await page.goto(url, wait_until="networkidle", timeout=timeout_ms)
+            await page.wait_for_timeout(1500)
+            html = await page.content()
+            return BeautifulSoup(html, "html.parser")
+        finally:
+            await browser.close()
+
+
+def _fetch_with_playwright(url: str, timeout_ms: int = 60_000) -> BeautifulSoup:
+    try:
+        asyncio.get_running_loop()
+        loop_running = True
+    except RuntimeError:
+        loop_running = False
+
+    if not loop_running:
+        return asyncio.run(_fetch_with_playwright_async(url, timeout_ms))
+
+    result: dict[str, BeautifulSoup] = {}
+    error: dict[str, Exception] = {}
+
+    def _runner() -> None:
+        try:
+            result["soup"] = asyncio.run(_fetch_with_playwright_async(url, timeout_ms))
+        except Exception as exc:
+            error["exc"] = exc
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join()
+
+    if "exc" in error:
+        raise error["exc"]
+    return result["soup"]
+
+
+def fetch_website_contents(url: str) -> str:
+    """
+    Return the title and contents of the website at the given url.
+    Uses requests first; falls back to Playwright for JS-heavy sites.
+    Truncates to 2,000 characters.
+    """
+    title, text = "Unable to fetch page", ""
+
+    try:
+        soup = _fetch_with_requests(url)
+        title, text = _clean_text_from_soup(soup)
+        if len(text) < MIN_TEXT_LENGTH:
+            soup = _fetch_with_playwright(url)
+            title, text = _clean_text_from_soup(soup)
+    except Exception:
+        try:
+            soup = _fetch_with_playwright(url)
+            title, text = _clean_text_from_soup(soup)
+        except Exception:
+            pass
+
+    return (title + "\n\n" + text)[:CHAR_LIMIT]
+
+
+def fetch_website_links(url: str) -> list[str]:
+    """Return href values from anchor tags on the page."""
+    try:
+        soup = _fetch_with_requests(url)
+        title, text = _clean_text_from_soup(soup)
+        if len(text) < MIN_TEXT_LENGTH:
+            soup = _fetch_with_playwright(url)
+    except Exception:
+        try:
+            soup = _fetch_with_playwright(url)
+        except Exception:
+            return []
+
+    links = [link.get("href") for link in soup.find_all("a")]
+    return [link for link in links if link]


### PR DESCRIPTION
## Summary
- Playwright fallback scraper for JavaScript-rendered websites (Week 1 Day 1 extra exercise)
- Demo notebook comparing basic requests vs Playwright, then summarizing three sites
- Works in Jupyter on Windows (handles existing event loop)

## Files
- `week1/community-contributions/slavapa/scraper_playwright.py`
- `week1/community-contributions/slavapa/day1_playwright_exercise.ipynb`
- `week1/community-contributions/slavapa/requirements.txt`
- `week1/community-contributions/slavapa/README.md`

## Test plan
- [ ] `uv pip install playwright && python -m playwright install chromium`
- [ ] Open `day1_playwright_exercise.ipynb`, select `.venv` kernel, run all cells
- [ ] Verify kabbalahmedia.info returns more content with Playwright than with basic scraper