### PR TITLE
Add Day 2 Ollama website summarizer

### DIFF
--- a/community-contributions/LabibCraftsSpells/wk1_day2_website_summarizer_qa_ollama.ipynb
+++ b/community-contributions/LabibCraftsSpells/wk1_day2_website_summarizer_qa_ollama.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ee86200b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d4255059",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openai = OpenAI(\n",
+    "    base_url=\"http://localhost:11434/v1\",\n",
+    "    api_key=\"ollama\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "90255a8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "headers = {\n",
+    "    \"User-Agent\": \"Mozilla/5.0\"\n",
+    "}\n",
+    "\n",
+    "\n",
+    "class Website:\n",
+    "    def __init__(self, url):\n",
+    "        self.url = url\n",
+    "\n",
+    "        response = requests.get(url, headers=headers)\n",
+    "        response.raise_for_status()\n",
+    "\n",
+    "        soup = BeautifulSoup(response.content, \"html.parser\")\n",
+    "\n",
+    "        self.title = soup.title.string if soup.title else \"No title found\"\n",
+    "\n",
+    "        if soup.body:\n",
+    "            for element in soup.body([\"script\", \"style\", \"img\", \"input\"]):\n",
+    "                element.decompose()\n",
+    "\n",
+    "            self.text = soup.body.get_text(\n",
+    "                separator=\"\\n\",\n",
+    "                strip=True\n",
+    "            )\n",
+    "        else:\n",
+    "            self.text = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f6690fba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"You are a brilliant professor with the personality of a witty stand-up comedian.\n",
+    "\n",
+    "Answer questions using ONLY the provided website content.\n",
+    "Never use outside knowledge or make things up.\n",
+    "If the answer isn't in the content, say you can't find it.\n",
+    "\n",
+    "Be clear, intelligent, funny, and occasionally sarcastic—\n",
+    "like a professor who teaches well and roasts students just enough\n",
+    "to keep them awake.\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b0591a20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def user_prompt(website, question):\n",
+    "    return f\"\"\"\n",
+    "Website title: {website.title}\n",
+    "\n",
+    "Website content:\n",
+    "{website.text}\n",
+    "\n",
+    "Question: {question}\n",
+    "\n",
+    "Answer the question based only on the website contents.\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "30ebe249",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(website, question):\n",
+    "    response = openai.chat.completions.create(\n",
+    "        model=\"llama3.2\",\n",
+    "        messages=[\n",
+    "            {\n",
+    "                \"role\": \"system\",\n",
+    "                \"content\": system_prompt\n",
+    "            },\n",
+    "            {\n",
+    "                \"role\": \"user\",\n",
+    "                \"content\": user_prompt(website, question)\n",
+    "            }\n",
+    "        ]\n",
+    "    )\n",
+    "\n",
+    "    return response.choices[0].message.content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "330ebe61",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Website: NASA\n",
+      "\n",
+      "My inquisitive students, the website you're looking at? Well, let me tell you, it's about NASA, folks! The National Aeronautics and Space Administration. This website is like a cosmic portal that takes you on a journey through NASA's various missions, scientists, astronauts, and all sorts of space-tastic topics! From exploring the International Space Station to searching for life on Mars (yes, there's that!), this site has it all. So, buckle up, class, and get ready for some out-of-this-world learning!\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = \"https://www.nasa.gov\"\n",
+    "\n",
+    "website = Website(url)\n",
+    "\n",
+    "print(f\"Website: {website.title}\\n\")\n",
+    "\n",
+    "question = \"What is this website about?\"\n",
+    "\n",
+    "print(ask(website, question))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Upgraded the Day 1 website summarizer to use the open-source Llama 3.2 model locally through Ollama instead of OpenAI.

* Uses Ollama for local inference
* No API charges
* Website content stays local
* Added the project as a Jupyter Notebook
