### PR TITLE
Add multi-provider brochure generator (Ollama/Gemini/Groq) 

### DIFF
--- a/community-contributions/week1-multi-provider-brochure-generator.ipynb
+++ b/community-contributions/week1-multi-provider-brochure-generator.ipynb
@@ -1,0 +1,607 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a98030af-fcd1-4d63-a36e-38ba053498fa",
+   "metadata": {},
+   "source": [
+    "# A full business solution\n",
+    "\n",
+    "## Now we will take our project from Day 1 to the next level\n",
+    "\n",
+    "### BUSINESS CHALLENGE:\n",
+    "\n",
+    "Create a product that builds a Brochure for a company to be used for prospective clients, investors and potential recruits.\n",
+    "\n",
+    "We will be provided a company name and their primary website.\n",
+    "\n",
+    "See the end of this notebook for examples of real-world business applications.\n",
+    "\n",
+    "And remember: I'm always available if you have problems or ideas! Please do reach out."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d5b08506-dc8b-4443-9201-5f1848161363",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "# If these fail, please check you're running from an 'activated' environment with (llms) in the command prompt\n",
+    "\n",
+    "import os\n",
+    "import json\n",
+    "from dotenv import load_dotenv\n",
+    "from IPython.display import Markdown, display, update_display\n",
+    "from scraper import fetch_website_links, fetch_website_contents\n",
+    "from openai import OpenAI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36eba2b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "print(\"GEMINI_API_KEY:\", \"SET\" if os.getenv(\"GEMINI_API_KEY\") else \"NOT SET\")\n",
+    "print(\"GROQ_API_KEY:\", \"SET\" if os.getenv(\"GROQ_API_KEY\") else \"NOT SET\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f14dca2c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "# --- Configuración de clientes ---\n",
+    "\n",
+    "# Cliente Gemini\n",
+    "GEMINI_BASE_URL = \"https://generativelanguage.googleapis.com/v1beta/openai/\"\n",
+    "gemini_api_key = os.getenv(\"GEMINI_API_KEY\")\n",
+    "gemini = OpenAI(base_url=GEMINI_BASE_URL, api_key=gemini_api_key)\n",
+    "\n",
+    "# Cliente Groq\n",
+    "GROQ_BASE_URL = \"https://api.groq.com/openai/v1\"\n",
+    "groq_api_key = os.getenv(\"GROQ_API_KEY\")\n",
+    "groq = OpenAI(base_url=GROQ_BASE_URL, api_key=groq_api_key)\n",
+    "\n",
+    "# Cliente Ollama (local)\n",
+    "ollama = OpenAI(base_url=\"http://localhost:11434/v1\", api_key=\"ollama\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0189948b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ask(messages, provider=\"ollama\", response_format=None, max_retries=3):\n",
+    "    kwargs = {\"messages\": messages}\n",
+    "    if response_format:\n",
+    "        kwargs[\"response_format\"] = response_format\n",
+    "\n",
+    "    last_error = None\n",
+    "    for attempt in range(max_retries):\n",
+    "        try:\n",
+    "            if provider == \"gemini\":\n",
+    "                response = gemini.chat.completions.create(model=\"gemini-3.1-flash-lite\", **kwargs)\n",
+    "            elif provider == \"groq\":\n",
+    "                response = groq.chat.completions.create(model=\"openai/gpt-oss-20b\", **kwargs)\n",
+    "            else:\n",
+    "                response = ollama.chat.completions.create(model=\"llama3.2:3b\", **kwargs)\n",
+    "            return response.choices[0].message.content\n",
+    "        except Exception as e:\n",
+    "            error_str = str(e)\n",
+    "            if \"503\" in error_str and provider == \"gemini\" and attempt < max_retries - 1:\n",
+    "                wait_time = 2 ** attempt\n",
+    "                print(f\"Gemini overloaded. Retrying in {wait_time}s...\")\n",
+    "                time.sleep(wait_time)\n",
+    "                last_error = e\n",
+    "                continue\n",
+    "            raise\n",
+    "    if last_error:\n",
+    "        raise last_error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e30d8128-933b-44cc-81c8-ab4c9d86589a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "links = fetch_website_links(\"https://edwarddonner.com\")\n",
+    "links"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1771af9c-717a-4fca-bbbe-8a95893312c3",
+   "metadata": {},
+   "source": [
+    "## First step: Have GPT-5-nano figure out which links are relevant\n",
+    "\n",
+    "### Use a call to gpt-5-nano to read the links on a webpage, and respond in structured JSON.  \n",
+    "It should decide which links are relevant, and replace relative links such as \"/about\" with \"https://company.com/about\".  \n",
+    "We will use \"one shot prompting\" in which we provide an example of how it should respond in the prompt.\n",
+    "\n",
+    "This is an excellent use case for an LLM, because it requires nuanced understanding. Imagine trying to code this without LLMs by parsing and analyzing the webpage - it would be very hard!\n",
+    "\n",
+    "Sidenote: there is a more advanced technique called \"Structured Outputs\" in which we require the model to respond according to a spec. We cover this technique in Week 8 during our autonomous Agentic AI project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6957b079-0d96-45f7-a26a-3487510e9b35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "link_system_prompt = \"\"\"You are provided with a list of links found on a webpage.\n",
+    "You must decide which links are relevant for a company brochure (About, Company, Careers/Jobs pages).\n",
+    "\n",
+    "CRITICAL FORMAT RULES:\n",
+    "- Respond with ONLY valid JSON, nothing else (no explanation, no markdown).\n",
+    "- Each link must have exactly two fields: \"type\" (a short label) and \"url\" (a single string).\n",
+    "- The \"url\" field must ALWAYS be a single string, NEVER a list.\n",
+    "- If there are multiple links of the same type (e.g. multiple social media links), \n",
+    "  create a SEPARATE entry for each one — do not group them into a list.\n",
+    "- Do not include Terms of Service, Privacy Policy, or mailto: links.\n",
+    "\n",
+    "Example of CORRECT format:\n",
+    "{\n",
+    "    \"links\": [\n",
+    "        {\"type\": \"about page\", \"url\": \"https://company.com/about\"},\n",
+    "        {\"type\": \"careers page\", \"url\": \"https://company.com/careers\"},\n",
+    "        {\"type\": \"twitter\", \"url\": \"https://twitter.com/company\"},\n",
+    "        {\"type\": \"linkedin\", \"url\": \"https://linkedin.com/company/company\"}\n",
+    "    ]\n",
+    "}\n",
+    "\n",
+    "Example of INCORRECT format (do not do this):\n",
+    "{\n",
+    "    \"links\": [\n",
+    "        {\"type\": \"social media\", \"url\": [\"https://twitter.com/company\", \"https://linkedin.com/company\"]}\n",
+    "    ]\n",
+    "}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e1f601b-2eaf-499d-b6b8-c99050c9d6b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_links_user_prompt(url):\n",
+    "    user_prompt = f\"\"\"\n",
+    "Here is the list of links on the website {url} -\n",
+    "Please decide which of these are relevant web links for a brochure about the company, \n",
+    "respond with the full https URL in JSON format.\n",
+    "Do not include Terms of Service, Privacy, email links.\n",
+    "\n",
+    "Links (some might be relative links):\n",
+    "\n",
+    "\"\"\"\n",
+    "    links = fetch_website_links(url)\n",
+    "    user_prompt += \"\\n\".join(links)\n",
+    "    return user_prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bcbfa78-6395-4685-b92c-22d592050fd7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(get_links_user_prompt(\"https://edwarddonner.com\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42b0cd4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def select_relevant_links(url, provider=\"ollama\"):\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": link_system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": get_links_user_prompt(url)}\n",
+    "    ]\n",
+    "    result = ask(messages, provider=provider, response_format={\"type\": \"json_object\"})\n",
+    "    return json.loads(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "490de841",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d5b1ded",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_relevant_links(\"https://edwarddonner.com\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74a827a0-2782-4ae5-b210-4a242a8b4cc2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_relevant_links(\"https://edwarddonner.com\",provider=\"gemini\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "995b5cc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_relevant_links(\"https://edwarddonner.com\",provider=\"groq\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3d583e2-dcc4-40cc-9b28-1e8dbf402924",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "select_relevant_links(\"https://huggingface.co\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d74128e-dfb6-47ec-9549-288b621c838c",
+   "metadata": {},
+   "source": [
+    "## Second step: make the brochure!\n",
+    "\n",
+    "Assemble all the details into another prompt to GPT-5-nano"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "285e6bbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.parse import urlparse\n",
+    "\n",
+    "def is_valid_url(url):\n",
+    "    try:\n",
+    "        result = urlparse(url)\n",
+    "        return all([result.scheme in (\"http\", \"https\"), result.netloc]) and \" \" not in url\n",
+    "    except:\n",
+    "        return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85a5b6e2-e7ef-44a9-bc7f-59ede71037b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from urllib.parse import urljoin\n",
+    "\n",
+    "def fetch_page_and_all_relevant_links(url):\n",
+    "    contents = fetch_website_contents(url)\n",
+    "    relevant_links = select_relevant_links(url)\n",
+    "    result = f\"## Landing Page:\\n\\n{contents}\\n## Relevant Links:\\n\"\n",
+    "\n",
+    "    seen_urls = {url}  # including landing pages\n",
+    "    for link in relevant_links['links']:\n",
+    "        link_url = urljoin(url, link[\"url\"].strip())  # solving issue with URL base\n",
+    "        if not is_valid_url(link_url):\n",
+    "            print(f\"Skipping invalid URL: {link_url}\")\n",
+    "            continue\n",
+    "        if link_url in seen_urls:\n",
+    "            print(f\"Skipping duplicate URL: {link_url}\")\n",
+    "            continue\n",
+    "        seen_urls.add(link_url)\n",
+    "        result += f\"\\n\\n### Link: {link['type']}\\n\"\n",
+    "        result += fetch_website_contents(link_url)\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5099bd14-076d-4745-baf3-dac08d8e5ab2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(fetch_page_and_all_relevant_links(\"https://huggingface.co\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b863a55-f86c-4e3f-8a79-94e24c1a8cf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "brochure_system_prompt = \"\"\"\n",
+    "You are an assistant that analyzes the contents of several relevant pages from a company website\n",
+    "and creates a short brochure about the company for prospective customers, investors and recruits.\n",
+    "Respond in markdown without code blocks.\n",
+    "Include details of company culture, customers and careers/jobs ONLY if you have the information.\n",
+    "CRITICAL: Do not invent or infer ANY specific factual details that are not explicitly stated \n",
+    "in the provided content. This includes but is not limited to: founding dates, office locations, \n",
+    "follower/user counts, specific URLs, email addresses, phone numbers, physical addresses, \n",
+    "social media handles, or statistics of any kind. If you don't have this information, either \n",
+    "omit it entirely or state generally that the company offers X without specific unverified numbers.\n",
+    "\"\"\"\n",
+    "\n",
+    "# Or uncomment the lines below for a more humorous brochure - this demonstrates how easy it is to incorporate 'tone':\n",
+    "\n",
+    "# brochure_system_prompt = \"\"\"\n",
+    "# You are an assistant that analyzes the contents of several relevant pages from a company website\n",
+    "# and creates a short, humorous, entertaining, witty brochure about the company for prospective customers, investors and recruits.\n",
+    "# Respond in markdown without code blocks.\n",
+    "# Include details of company culture, customers and careers/jobs if you have the information.\n",
+    "# \"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ab83d92-d36b-4ce0-8bcc-5bb4c2f8ff23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_brochure_user_prompt(company_name, url):\n",
+    "    user_prompt = f\"\"\"\n",
+    "You are looking at a company called: {company_name}\n",
+    "Here are the contents of its landing page and other relevant pages;\n",
+    "use this information to build a short brochure of the company in markdown without code blocks.\\n\\n\n",
+    "\"\"\"\n",
+    "    user_prompt += fetch_page_and_all_relevant_links(url)\n",
+    "    user_prompt = user_prompt[:5_000] # Truncate if more than 5,000 characters\n",
+    "    return user_prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd909e0b-1312-4ce2-a553-821e795d7572",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_brochure_user_prompt(\"HuggingFace\", \"https://huggingface.co\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84f12062",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b45846d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "def create_brochure(company_name, url, provider=\"gemini\"):\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": brochure_system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": get_brochure_user_prompt(company_name, url)}\n",
+    "    ]\n",
+    "    result = ask(messages, provider=provider)\n",
+    "    display(Markdown(result))\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b123615a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_brochure(\"HuggingFace\", \"https://huggingface.co\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7d7131f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "create_brochure(\"HuggingFace\", \"https://huggingface.co\",provider=\"groq\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61eaaab7-0b47-4b29-82d4-75d474ad8d18",
+   "metadata": {},
+   "source": [
+    "## Finally - a minor improvement\n",
+    "\n",
+    "With a small adjustment, we can change this so that the results stream back from OpenAI,\n",
+    "with the familiar typewriter animation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d794884f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stream_brochure(company_name, url, provider=\"gemini\"):\n",
+    "    messages = [\n",
+    "        {\"role\": \"system\", \"content\": brochure_system_prompt},\n",
+    "        {\"role\": \"user\", \"content\": get_brochure_user_prompt(company_name, url)}\n",
+    "    ]\n",
+    "\n",
+    "    if provider == \"gemini\":\n",
+    "        client, model = gemini, \"gemini-3.1-flash-lite\"\n",
+    "    elif provider == \"groq\":\n",
+    "        client, model = groq, \"openai/gpt-oss-20b\"\n",
+    "    else:\n",
+    "        client, model = ollama, \"llama3.2:3b\"\n",
+    "\n",
+    "    stream = client.chat.completions.create(model=model, messages=messages, stream=True)\n",
+    "\n",
+    "    response = \"\"\n",
+    "    display_handle = display(Markdown(\"\"), display_id=True)\n",
+    "    for chunk in stream:\n",
+    "        response += chunk.choices[0].delta.content or ''\n",
+    "        update_display(Markdown(response), display_id=display_handle.display_id)\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56bf0ae3-ee9d-4a72-9cd6-edcac67ceb6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stream_brochure(\"HuggingFace\", \"https://huggingface.co\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdb3f8d8-a3eb-41c8-b1aa-9f60686a653b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Try changing the system prompt to the humorous version when you make the Brochure for Hugging Face:\n",
+    "\n",
+    "stream_brochure(\"HuggingFace\", \"https://huggingface.co\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a27bf9e0-665f-4645-b66b-9725e2a959b5",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left;\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../assets/business.jpg\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#181;\">Business applications</h2>\n",
+    "            <span style=\"color:#181;\">In this exercise we extended the Day 1 code to make multiple LLM calls, and generate a document.\n",
+    "\n",
+    "This is perhaps the first example of Agentic AI design patterns, as we combined multiple calls to LLMs. This will feature more in Week 2, and then we will return to Agentic AI in a big way in Week 8 when we build a fully autonomous Agent solution.\n",
+    "\n",
+    "Generating content in this way is one of the very most common Use Cases. As with summarization, this can be applied to any business vertical. Write marketing content, generate a product tutorial from a spec, create personalized email content, and so much more. Explore how you can apply content generation to your business, and try making yourself a proof-of-concept prototype. See what other students have done in the community-contributions folder -- so many valuable projects -- it's wild!</span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14b2454b-8ef8-4b5c-b928-053a15e0d553",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left;\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../assets/important.jpg\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#900;\">Before you move to Week 2 (which is tons of fun)</h2>\n",
+    "            <span style=\"color:#900;\">Please see the week1 EXERCISE notebook for your challenge for the end of week 1. This will give you some essential practice working with Frontier APIs, and prepare you well for Week 2.</span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17b64f0f-7d33-4493-985a-033d06e8db08",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left;\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../assets/resources.jpg\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#f71;\">A reminder on 3 useful resources</h2>\n",
+    "            <span style=\"color:#f71;\">1. The resources for the course are available <a href=\"https://edwarddonner.com/2024/11/13/llm-engineering-resources/\">here.</a><br/>\n",
+    "            2. I'm on LinkedIn <a href=\"https://www.linkedin.com/in/eddonner/\">here</a> and I love connecting with people taking the course!<br/>\n",
+    "            3. I'm trying out X/Twitter and I'm at <a href=\"https://x.com/edwarddonner\">@edwarddonner<a> and hoping people will teach me how it's done..  \n",
+    "            </span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f48e42e-fa7a-495f-a5d4-26bfc24d60b6",
+   "metadata": {},
+   "source": [
+    "<table style=\"margin: 0; text-align: left;\">\n",
+    "    <tr>\n",
+    "        <td style=\"width: 150px; height: 150px; vertical-align: middle;\">\n",
+    "            <img src=\"../assets/thankyou.jpg\" width=\"150\" height=\"150\" style=\"display: block;\" />\n",
+    "        </td>\n",
+    "        <td>\n",
+    "            <h2 style=\"color:#090;\">Finally! I have a special request for you</h2>\n",
+    "            <span style=\"color:#090;\">\n",
+    "                My editor tells me that it makes a MASSIVE difference when students rate this course on Udemy - it's one of the main ways that Udemy decides whether to show it to others. If you're able to take a minute to rate this, I'd be so very grateful! And regardless - always please reach out to me at ed@edwarddonner.com if I can help at any point.\n",
+    "            </span>\n",
+    "        </td>\n",
+    "    </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "llm-engineering (3.12.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adds a brochure generator supporting three providers: Ollama (local), Gemini, and Groq.

- Robust link extraction with URL validation and deduplication
- System prompt updated to avoid hallucinating company details (locations, contact info, etc.) not present in the scraped content
- Retry with exponential backoff for transient API errors