### PR TITLE
add UI-driven synthetic data generation from JSON schema

### DIFF
--- a/week3/community-contributions/himanshu/week3_assignment.ipynb
+++ b/week3/community-contributions/himanshu/week3_assignment.ipynb
@@ -1,0 +1,533 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e1450c59",
+   "metadata": {},
+   "source": [
+    "# Synthetic Data Generator - Week 3 Assignment\n",
+    "\n",
+    "## Submitted By: Isaac Ifeakachi Nwankwo (issoft2)\n",
+    "\n",
+    "# Summary\n",
+    "\n",
+    "- Implemented a synthetic data generator using the transformer architure directly.\n",
+    "- Used AutoTokenizer and AutoModelForCausalLM for manual inference.\n",
+    "- Demonstrated core transformer flow:Tokenize ---> Generate ---> Decode.\n",
+    "- Wrapped the logic in a Gradio UI for usability.\n",
+    "- Used a small model\n",
+    "- Fully aligned with week 3 challenge: \"Write models that generate datasets and explore model APIs.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b617a1c",
+   "metadata": {},
+   "source": [
+    "# Pip installations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f0cbc64",
+   "metadata": {},
+   "source": [
+    "# Synthetic Data Generator - Week 3 Assignment\n",
+    "\n",
+    "## Submitted By: Isaac Ifeakachi Nwankwo (issoft2)\n",
+    "\n",
+    "# Summary\n",
+    "\n",
+    "- Implemented a synthetic data generator using the transformer architure directly.\n",
+    "- Used AutoTokenizer and AutoModelForCausalLM for manual inference.\n",
+    "- Demonstrated core transformer flow:Tokenize ---> Generate ---> Decode.\n",
+    "- Wrapped the logic in a Gradio UI for usability.\n",
+    "- Used a small model\n",
+    "- Fully aligned with week 3 challenge: \"Write models that generate datasets and explore model APIs.\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06569e28",
+   "metadata": {},
+   "source": [
+    "# Pip installations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0799d0d1",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q transformers gradio torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4758857a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Default title text\n",
+    "# Let's chec the GPU - It should be NVIDIA Tesla T4\n",
+    "gpu_info = !nvidia-smi\n",
+    "gpu_info = '\\n'.join(gpu_info)\n",
+    "if gpu_info.find('Tesla T4') >= 0:\n",
+    "    print('GPU is Tesla T4')\n",
+    "else:   \n",
+    "    print('GPU is not Tesla T4')       "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1b74de87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import libraries\n",
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM\n",
+    "import gradio as gr\n",
+    "from huggingface_hub import login\n",
+    "from google.colab import userdata\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29b59401",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Login to Hugging Face Hub\n",
+    "hf_token = userdata.get(\"HF_TOKEN\")\n",
+    "login(hf_token, add_to_git_credential=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bcf5f749",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load Model and Tokenizer\n",
+    "model_name = \"google/flan-t5-base\"\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fdede71",
+   "metadata": {},
+   "source": [
+    "# Build a prompt\n",
+    "\n",
+    "Create a simple function to structure the generation task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d11a2a82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_prompt(region, count):\n",
+    "    return (\n",
+    "        f\"Generate {count} unique Nigeria names from the {region} region. \"\n",
+    "        f\"Include both male and femaile names. \"\n",
+    "        f\"Return the list numbered 1 to {count}.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28b705e",
+   "metadata": {},
+   "source": [
+    "# Tokenize, Generate and Decode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e65234cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gnerate_names(region, count):\n",
+    "    # Few examples to guide GTP2\n",
+    "    prompt = f\"\"\"\n",
+    "Generate {count} unique Nigerian names from the {region} region.and\n",
+    "Each name should be real and commonly used in that region in Nigeria\n",
+    "Include both male and female names.\n",
+    "Here are some examples:\n",
+    "\n",
+    "1. Jude Okafor\n",
+    "2. Adeola Adebayo\n",
+    "3. Chinedu Eze\n",
+    "4. Fatima Bello\n",
+    "5. Emeka Nwosu\n",
+    "\n",
+    "Now go ahead and generate the list of names based on the above examples.:\n",
+    "\"\"\"\n",
+    "\n",
+    "    # Model and tokenizer ...\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "    model = AutoModelForCausalLM.from_pretrained(model_name)\n",
+    "\n",
+    "    # Encode the input --\n",
+    "    inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "    # Generate output ...\n",
+    "    outputs = model.generate(\n",
+    "        **inputs,\n",
+    "        max_length=300,\n",
+    "        temperature=0.7,\n",
+    "        do_sample=True,\n",
+    "        pad_token_id=tokenizer.eos_token_id\n",
+    "    )\n",
+    "\n",
+    "    # Decode the output ...\n",
+    "    generated_text = tokenizer.decode(outputs[0], skip_special_tokens=True)\n",
+    "\n",
+    "    # Extract the names from the generated text ...\n",
+    "    lines = generated_text.split('\\n')\n",
+    "    names = []\n",
+    "    for line in lines:\n",
+    "        if any(ch.isalpha() for ch in line):\n",
+    "            name = line.strip()\n",
+    "            if \",\" in name:\n",
+    "                name = name.split(\",\", 1)[1].strip()\n",
+    "            if len(name.split()) >= 3 and not name.lower().startswith(\"generate\"):\n",
+    "                names.append(name)\n",
+    "\n",
+    "    names = list(dict.fromkeys(names))[:count]\n",
+    "\n",
+    "    if not names:\n",
+    "        names = [\"No names generated, please try again.\"]\n",
+    "\n",
+    "    return \"\\n\".join(names)     "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fa99aab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Catch error\n",
+    "import traceback\n",
+    "\n",
+    "def safe_generate_names(region, count):\n",
+    "    try:\n",
+    "        return generate_names(region, count)\n",
+    "    except Exception as e:\n",
+    "        return f\"Error:\\n{traceback.format_exc()}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc0bef88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Gradio Interface\n",
+    "\n",
+    "def run_application():\n",
+    "    with gr.Blocks() as demo:\n",
+    "        gr.Markdown(\"## Nigerian Name Generator\")\n",
+    "        gr.Markdown(\"Enter a Nigerian region and the number of names you want to generate. The model will return a list of unique Nigerian names from that region.\")\n",
+    "\n",
+    "        region = gr.Dropdown(\n",
+    "            [\"Yoruba\", \"Igbo\", \"Hausa\", \"Fulani\", \"Kanuri\", \"Tiv\", \"Ibibio\", \"Edo\", \"Nupe\", \"Ijaw\"],\n",
+    "            label=\"Select Region\"\n",
+    "            value=\"Yoruba\"\n",
+    "\n",
+    "        )\n",
+    "\n",
+    "        count = gr.Number(label=\"Number of Names\", value=20)\n",
+    "        output = gr.Textbox(label=\"Generated Nigeria Names\", lines=20)\n",
+    "        generate_button = gr.Button(\"Generate Names\")\n",
+    "\n",
+    "        generate_button.click(fn=gnerate_names, inputs=[region, count], outputs=output)\n",
+    "\n",
+    "    demo.launch()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3cb8886",
+   "metadata": {},
+   "source": [
+    "# Run App\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "712a1f5d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_application()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8b68c97",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -q transformers gradio torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2704435d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# @title Default title text\n",
+    "# Let's chec the GPU - It should be NVIDIA Tesla T4\n",
+    "gpu_info = !nvidia-smi\n",
+    "gpu_info = '\\n'.join(gpu_info)\n",
+    "if gpu_info.find('Tesla T4') >= 0:\n",
+    "    print('GPU is Tesla T4')\n",
+    "else:   \n",
+    "    print('GPU is not Tesla T4')       "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8bf5b18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import libraries\n",
+    "import torch\n",
+    "from transformers import AutoTokenizer, AutoModelForCausalLM\n",
+    "import gradio as gr\n",
+    "from huggingface_hub import login\n",
+    "from google.colab import userdata\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60bc3034",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Login to Hugging Face Hub\n",
+    "hf_token = userdata.get(\"HF_TOKEN\")\n",
+    "login(hf_token, add_to_git_credential=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70433ab4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load Model and Tokenizer\n",
+    "model_name = \"google/flan-t5-base\"\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e29dd61",
+   "metadata": {},
+   "source": [
+    "# Build a prompt\n",
+    "\n",
+    "Create a simple function to structure the generation task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3cef2ce6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def build_prompt(region, count):\n",
+    "    return (\n",
+    "        f\"Generate {count} unique Nigeria names from the {region} region. \"\n",
+    "        f\"Include both male and femaile names. \"\n",
+    "        f\"Return the list numbered 1 to {count}.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f67bbb9",
+   "metadata": {},
+   "source": [
+    "# Tokenize, Generate and Decode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ea4de98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gnerate_names(region, count):\n",
+    "    # Few examples to guide GTP2\n",
+    "    prompt = f\"\"\"\n",
+    "Generate {count} unique Nigerian names from the {region} region.and\n",
+    "Each name should be real and commonly used in that region in Nigeria\n",
+    "Include both male and female names.\n",
+    "Here are some examples:\n",
+    "\n",
+    "1. Jude Okafor\n",
+    "2. Adeola Adebayo\n",
+    "3. Chinedu Eze\n",
+    "4. Fatima Bello\n",
+    "5. Emeka Nwosu\n",
+    "\n",
+    "Now go ahead and generate the list of names based on the above examples.:\n",
+    "\"\"\"\n",
+    "\n",
+    "    # Model and tokenizer ...\n",
+    "    tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+    "    model = AutoModelForCausalLM.from_pretrained(model_name)\n",
+    "\n",
+    "    # Encode the input --\n",
+    "    inputs = tokenizer(prompt, return_tensors=\"pt\")\n",
+    "\n",
+    "    # Generate output ...\n",
+    "    outputs = model.generate(\n",
+    "        **inputs,\n",
+    "        max_length=300,\n",
+    "        temperature=0.7,\n",
+    "        do_sample=True,\n",
+    "        pad_token_id=tokenizer.eos_token_id\n",
+    "    )\n",
+    "\n",
+    "    # Decode the output ...\n",
+    "    generated_text = tokenizer.decode(outputs[0], skip_special_tokens=True)\n",
+    "\n",
+    "    # Extract the names from the generated text ...\n",
+    "    lines = generated_text.split('\\n')\n",
+    "    names = []\n",
+    "    for line in lines:\n",
+    "        if any(ch.isalpha() for ch in line):\n",
+    "            name = line.strip()\n",
+    "            if \",\" in name:\n",
+    "                name = name.split(\",\", 1)[1].strip()\n",
+    "            if len(name.split()) >= 3 and not name.lower().startswith(\"generate\"):\n",
+    "                names.append(name)\n",
+    "\n",
+    "    names = list(dict.fromkeys(names))[:count]\n",
+    "\n",
+    "    if not names:\n",
+    "        names = [\"No names generated, please try again.\"]\n",
+    "\n",
+    "    return \"\\n\".join(names)     "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cda828c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Catch error\n",
+    "import traceback\n",
+    "\n",
+    "def safe_generate_names(region, count):\n",
+    "    try:\n",
+    "        return generate_names(region, count)\n",
+    "    except Exception as e:\n",
+    "        return f\"Error:\\n{traceback.format_exc()}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b27e9d4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Gradio Interface\n",
+    "\n",
+    "def run_application():\n",
+    "    with gr.Blocks() as demo:\n",
+    "        gr.Markdown(\"## Nigerian Name Generator\")\n",
+    "        gr.Markdown(\"Enter a Nigerian region and the number of names you want to generate. The model will return a list of unique Nigerian names from that region.\")\n",
+    "\n",
+    "        region = gr.Dropdown(\n",
+    "            [\"Yoruba\", \"Igbo\", \"Hausa\", \"Fulani\", \"Kanuri\", \"Tiv\", \"Ibibio\", \"Edo\", \"Nupe\", \"Ijaw\"],\n",
+    "            label=\"Select Region\"\n",
+    "            value=\"Yoruba\"\n",
+    "\n",
+    "        )\n",
+    "\n",
+    "        count = gr.Number(label=\"Number of Names\", value=20)\n",
+    "        output = gr.Textbox(label=\"Generated Nigeria Names\", lines=20)\n",
+    "        generate_button = gr.Button(\"Generate Names\")\n",
+    "\n",
+    "        generate_button.click(fn=gnerate_names, inputs=[region, count], outputs=output)\n",
+    "\n",
+    "    demo.launch()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8cb286d",
+   "metadata": {},
+   "source": [
+    "# Run App\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e5b3b52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_application()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added schema-driven synthetic data generation using Llama 3.2 3B Instruct.

- Allow users to define JSON schemas through the UI
- Generate realistic fictional records based on schema fields
- Use field keys, types, and descriptions to guide data generation
- Extract and parse JSON from model output
- Support generation of 20 synthetic records per request