### PR TITLE
Week 8: verify the price of the selected deal with a web search

### DIFF
--- a/week8/community_contributions/price_verification/README.md
+++ b/week8/community_contributions/price_verification/README.md
@@ -1,0 +1,104 @@
+# Price verification after the selection
+
+## Why
+
+The estimate comes from the ensemble: a frontier model doing RAG over Amazon Reviews 2023, the
+fine-tuned pricer from week 7, and the neural network from week 6. All three sit in the same 2023
+price world, and train, validation and test are slices of the same shuffled data, so the week 6 and
+week 7 numbers say how well they predict 2023 prices, not today's. The prompt carries no date, so
+nothing in the chain can answer for another year, and more training does not fix it, because the
+information is not in the data. What carries over to today is the ranking between products, not the
+price level.
+
+That matters for week 8, because a discount is the estimate minus the asking price. If the estimate
+sits at a 2023 price level, so does the discount, and a deal can clear the threshold on the gap
+between two years rather than on a real saving.
+
+So for products that can be identified one to one at another retailer, this checks the estimate
+against a price that exists today, and measures the saving against that instead.
+
+## What it does
+
+Once the planner has picked the best deal of a run, it looks up what that product currently sells
+for elsewhere, and measures the discount against that price. The threshold test then runs on the
+looked up price, so a deal that only cleared the threshold on a high estimate is dropped. Five deals
+are estimated and only the winner is looked up, so this is one web search per run.
+
+## Why the pipeline stays as it is
+
+The obvious alternative is to drop the estimate and look up every deal instead. That does not work
+here. A lookup only returns something when one specific product can be identified, which is not true
+for a lot of what the scanner surfaces, and it costs a web search per deal rather than one per run.
+The ensemble is what can put a number on everything, including the products no other retailer lists,
+so it stays as the thing that ranks the five candidates. The lookup is the check on the one that
+comes out on top.
+
+## What it measures against
+
+The lowest valid listing, not an average or a median across retailers. The question is not what the
+product is worth, it is whether the same thing can be bought cheaper somewhere else, so the cheapest
+offer is what the saving should be measured against.
+
+That puts the weight on what counts as a listing, and those conditions are set in the system prompt,
+and repeated in the field descriptions of the schema: the same product matched on model number, the
+same condition, sold by the retailer itself rather than a third party on a marketplace, and a price
+a shopper pays today rather than an MSRP or a limited time promotion. Every listing carries the URL
+it came from.
+
+## What it can and cannot do
+
+This only works for deals where one specific product can be identified at another retailer. The
+conditions are strict on purpose: the same model number, the same condition, sold by the retailer
+itself. When the product cannot be pinned down that way the lookup returns `found=false`, the
+estimate stays, and the deal is handled exactly as before. Those deals keep the 2023 baseline, so
+this narrows the problem rather than removing it.
+
+It does not correct the estimates themselves and it does not say how far off the model is in
+general. It re-bases the one deal that was picked, on one lookup per run. This also means the
+ensemble still decides which deal gets checked. A deal it undervalued is never looked up.
+
+## Files
+
+- `verifier_agent.py`: the `VerifierAgent`. It calls the OpenAI Responses API with the `web_search`
+  tool on `gpt-5.1`, using the `OPENAI_API_KEY` the course already uses, and returns the cheapest
+  valid listing or `None`.
+- `verifying_planning_agent.py`: `VerifyingPlanningAgent`, a subclass of `PlanningAgent` with the
+  verification step in `plan()`, and `VerifiedOpportunity`, an `Opportunity` with `verified` and
+  `model_estimate` added so the models' own estimate is kept next to the verified price.
+
+Nothing in `week8` is changed. When `DealAgentFramework` reads `memory.json` back it builds an
+`Opportunity`, so those two extra fields are dropped on reload (checked with pydantic 2.11.10).
+
+## Running it
+
+From the `week8` directory:
+
+```python
+import sys
+sys.path.append("community_contributions/price_verification")
+
+from deal_agent_framework import DealAgentFramework
+from verifying_planning_agent import VerifyingPlanningAgent
+
+framework = DealAgentFramework()
+framework.planner = VerifyingPlanningAgent(framework.collection)
+framework.run()
+```
+
+## What it did, measured on 2026-09-06
+
+- A mini PC advertised at $329 was estimated at $510.29, a discount of $181.29 and well over the
+  threshold of $50. The lowest listing found online was $363.53, which makes the real saving $34.53,
+  below the threshold. No alert was sent.
+- A signage display from a brand with no second retailer returned `found=false`, so the estimate
+  stayed and the deal was handled exactly as before.
+
+## How reliable a verified price is
+
+The lookup is itself a draw. The same product, an LG S80TR soundbar, returned $599.99, $909.99 and
+$699.99 over three lookups, at LG and Walmart, at Target, and at Best Buy. Within one lookup the
+listings are consistent, between lookups they are not. So verified here means a real price for this
+exact product on that lookup, not the market price.
+
+How often a lookup succeeds over a longer series has not been measured, and neither has the effect
+on the number of alerts over time. Both figures above come from a single run each.

--- a/week8/community_contributions/price_verification/verifier_agent.py
+++ b/week8/community_contributions/price_verification/verifier_agent.py
@@ -1,0 +1,113 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+from openai import OpenAI
+from agents.agent import Agent
+
+
+class Listing(BaseModel):
+    """
+    One offer for a product at one retailer
+    """
+
+    retailer: str = Field(description="The name of the store selling it, for example Walmart or Best Buy")
+    price: float = Field(description="The current selling price in US dollars at this retailer")
+    url: str = Field(description="The URL of the page this price came from. Never invent one.")
+
+
+class PriceLookup(BaseModel):
+    """
+    What a product currently sells for, according to a web search
+    """
+
+    found: bool = Field(
+        description="True only if you identified this exact product and found at least one real offer for it"
+    )
+    product_name: str = Field(description="The full name of the product you found, including its model number")
+    listings: List[Listing] = Field(
+        description="Every offer you found for this exact product, one entry per retailer. Leave empty if found is false."
+    )
+
+
+class VerifiedPrice(BaseModel):
+    """
+    The cheapest way to buy this product elsewhere, which is what a deal should be measured against
+    """
+
+    product_name: str
+    price: float
+    retailer: str
+    url: str
+    highest: float
+    count: int
+
+
+class VerifierAgent(Agent):
+    name = "Verifier Agent"
+    color = Agent.MAGENTA
+
+    MODEL = "gpt-5.1"
+
+    SYSTEM_PROMPT = """You look up what a product currently sells for, using web search.
+
+Search several retailers, not just the first one you find, and report every offer you find as a separate listing with the retailer, the price and the URL it came from.
+
+A listing only counts if all of these hold:
+- it is the same product, matching on model number where there is one
+- it is in the same condition as the product described, so do not offer a refurbished unit for a new product or the other way around
+- it is sold by the retailer itself, not by a third party seller on a marketplace
+- the price is what a shopper pays today, not the manufacturer's list price or MSRP, and not a limited time promotional or clearance price
+
+Never invent a listing or a URL. Reporting fewer listings is fine, and reporting none is much better than reporting the price of a similar but different product. If the description is too vague to identify one specific product, or you cannot find that product for sale, set found to false and return no listings."""
+
+    def __init__(self):
+        self.log("Verifier Agent is initializing")
+        self.client = OpenAI()
+        self.log("Verifier Agent is ready")
+
+    def lookup(self, description: str) -> Optional[VerifiedPrice]:
+        """
+        Search the web for what this product sells for elsewhere
+        :param description: the product description scraped from the deal
+        :return: the cheapest valid listing found, or None if the product could not be identified
+        """
+        self.log(f"Verifier Agent is searching the web using {self.MODEL}")
+        response = self.client.responses.parse(
+            model=self.MODEL,
+            tools=[{"type": "web_search"}],
+            input=[
+                {"role": "system", "content": self.SYSTEM_PROMPT},
+                {"role": "user", "content": description},
+            ],
+            text_format=PriceLookup,
+        )
+        result = response.output_parsed
+        if not result or not result.found:
+            self.log("Verifier Agent could not identify this product online")
+            return None
+
+        # The schema allows any number and any list, so drop anything that cannot be an offer
+        listings = [listing for listing in result.listings if listing.price > 0 and listing.url]
+        if not listings:
+            self.log("Verifier Agent found no usable listings for this product")
+            return None
+
+        cheapest = listings[0]
+        highest = listings[0].price
+        for listing in listings:
+            if listing.price < cheapest.price:
+                cheapest = listing
+            if listing.price > highest:
+                highest = listing.price
+
+        self.log(
+            f"Verifier Agent found {len(listings)} listing(s) for {result.product_name}, "
+            f"cheapest ${cheapest.price:.2f} at {cheapest.retailer}, highest ${highest:.2f}"
+        )
+        return VerifiedPrice(
+            product_name=result.product_name,
+            price=cheapest.price,
+            retailer=cheapest.retailer,
+            url=cheapest.url,
+            highest=highest,
+            count=len(listings),
+        )

--- a/week8/community_contributions/price_verification/verifying_planning_agent.py
+++ b/week8/community_contributions/price_verification/verifying_planning_agent.py
@@ -1,0 +1,73 @@
+from typing import List, Optional
+from agents.deals import Opportunity
+from agents.planning_agent import PlanningAgent
+from verifier_agent import VerifierAgent
+
+
+class VerifiedOpportunity(Opportunity):
+    """
+    An Opportunity whose estimate was replaced by a price found online.
+    The estimate the models produced is kept in model_estimate.
+    """
+
+    verified: bool = False
+    model_estimate: Optional[float] = None
+
+
+class VerifyingPlanningAgent(PlanningAgent):
+    """
+    The PlanningAgent with one extra step. Once the best deal of a run has been picked,
+    look up what that product currently sells for elsewhere, and measure the discount
+    against that price instead of against the estimate. Five deals are estimated,
+    only the winner is looked up.
+    """
+
+    name = "Verifying Planning Agent"
+
+    def __init__(self, collection):
+        super().__init__(collection)
+        self.verifier = VerifierAgent()
+
+    def verify(self, opportunity: Opportunity) -> Opportunity:
+        """
+        Replace the estimate with a real price if one specific product could be identified
+        :param opportunity: the opportunity picked as the best of this run
+        :returns: the opportunity, verified where a price was found, unchanged otherwise
+        """
+        lookup = self.verifier.lookup(opportunity.deal.product_description)
+        if not lookup:
+            self.log("Planning Agent could not verify this price online, so it keeps the estimate")
+            return opportunity
+        self.log(
+            f"Planning Agent verified {lookup.product_name} at ${lookup.price:.2f} at {lookup.retailer} "
+            f"from {lookup.count} listing(s) up to ${lookup.highest:.2f}, "
+            f"where the models estimated ${opportunity.estimate:.2f}, see {lookup.url}"
+        )
+        return VerifiedOpportunity(
+            deal=opportunity.deal,
+            estimate=lookup.price,
+            discount=lookup.price - opportunity.deal.price,
+            verified=True,
+            model_estimate=opportunity.estimate,
+        )
+
+    def plan(self, memory: List[str] = []) -> Optional[Opportunity]:
+        """
+        The same workflow as the PlanningAgent, with the verification step
+        between picking the best deal and testing it against the threshold
+        :param memory: a list of URLs that have been surfaced in the past
+        :return: an Opportunity if one was surfaced, otherwise None
+        """
+        self.log("Planning Agent is kicking off a run")
+        selection = self.scanner.scan(memory=memory)
+        if selection:
+            opportunities = [self.run(deal) for deal in selection.deals[:5]]
+            opportunities.sort(key=lambda opp: opp.discount, reverse=True)
+            best = opportunities[0]
+            self.log(f"Planning Agent has identified the best deal has discount ${best.discount:.2f}")
+            best = self.verify(best)
+            if best.discount > self.DEAL_THRESHOLD:
+                self.messenger.alert(best)
+            self.log("Planning Agent has completed a run")
+            return best if best.discount > self.DEAL_THRESHOLD else None
+        return None


### PR DESCRIPTION
Deals in week 8 are ranked on the estimate minus the asking price, and that estimate comes from the
ensemble: a frontier model doing RAG over Amazon Reviews 2023, the fine-tuned pricer from week 7, and
the neural network from week 6. All three sit in the same 2023 price world, and the test set is a
slice of the same shuffled data, so those numbers say how well the models predict 2023 prices. The
prompt carries no date, so the models cannot answer for another year. The ranking between products
carries over to today, the price level does not, which means a deal can clear the threshold on the
gap between two years rather than on a real saving.

This adds one step to the planner, in week8/community_contributions/price_verification/. Once the
best deal of a run has been picked, it looks up what that product currently sells for elsewhere with
the OpenAI Responses API and the web_search tool, and measures the discount against that price. The
threshold test then runs on the looked up price. Five deals are estimated and only the winner is
looked up, so it is one search per run. Looking up every deal instead is not an alternative: a lookup
needs one identifiable product and costs a search per deal, while the ensemble can price everything,
so it stays as the thing that ranks the candidates.

It only works where one specific product can be identified at another retailer: the same model
number, the same condition, sold by the retailer itself, and a price paid today rather than an MSRP
or a promotion. Those conditions are set in the system prompt and repeated in the field descriptions
of the schema, and every listing carries a URL. When the product cannot be pinned down that way the
lookup returns found=false, the estimate stays and the deal is handled as before. It measures against
the lowest valid listing rather than an average, because the question is whether the same product can
be bought cheaper somewhere else.

Measured on 2026-09-06, one run each. A mini PC advertised at $329 was estimated at $510.29, a
discount of $181.29 and over the threshold of $50; the lowest listing online was $363.53, which makes
the real saving $34.53 and drops it below the threshold. A signage display from a brand with no
second retailer returned found=false, so the estimate stayed and the deal was handled as before.

The lookup is a draw in itself: the same soundbar returned $599.99, $909.99 and $699.99 over three
lookups at three retailers. Within one lookup the listings are consistent, between lookups they are
not. How often a lookup succeeds over a longer series has not been measured.

Three files, no notebooks, nothing outside community_contributions. VerifyingPlanningAgent subclasses
PlanningAgent, so nothing in week8 changes.
